### PR TITLE
feat(docker): Stage 1 - Docker foundation environment

### DIFF
--- a/.agents/MIGRATION-PLAN.md
+++ b/.agents/MIGRATION-PLAN.md
@@ -1,7 +1,7 @@
 # Tuqan PHP 8 + Docker + Testing Migration Plan
 
 **Branch:** `php-migration-plan-docker-testing` (created 2026-05)  
-**Status:** Planning complete — awaiting approval to execute Stage 1  
+**Status:** Stage 1 (Docker Foundation) completed on 2026-05-25. Ready for Stage 2.  
 **Goal:** Migrate the legacy Tuqan/Qnova ISO 9001/14001 application to a maintainable, tested, PHP 8.3+ state with a 100% Docker-based development environment. Zero reliance on host PHP, nginx, or postgres.
 
 ## Executive Summary

--- a/.agents/STAGE-CHECKLISTS.md
+++ b/.agents/STAGE-CHECKLISTS.md
@@ -193,17 +193,34 @@ docker compose down
 
 ## Evidence Log (Append After Every Stage)
 
-**Stage 1 — COMPLETED (date here)**
+**Stage 1 — COMPLETED (2026-05-25)**
 
-```
-Docker version used: 29.3.1 (macOS)
-PHP inside container:
-PHP 8.3.x (cli) (built: ...)
-pdo_pgsql, gd, gettext, intl, zip, bcmath, opcache all present.
-DB: PostgreSQL 16.x
-curl -I http://localhost:8080 → 200/302 (or expected app 404)
-Evidence file: [paste key output or link to commit]
-Deviations: none / list here
+**Branch:** `stage-1-docker-foundation`
+
+**Evidence:**
+
+- Docker version: 29.3.1 (macOS, Docker Desktop)
+- PHP inside container: **PHP 8.3.31** (cli) + Xdebug 3.3.2 + OPcache
+- Extensions confirmed: `pdo_pgsql`, `pgsql`, `gd`, `gettext`, `intl`, `zip`, `bcmath`, `xdebug`
+- PostgreSQL: **16.14** (Alpine) — healthy and accepting connections
+- Nginx: Responding with **HTTP 200** + `X-Powered-By: PHP/8.3.31`
+- Stack started successfully with `docker compose --env-file .env.docker up -d`
+
+**Gotchas / Deviations:**
+- Old `version:` key in docker-compose.yml removed (was generating warning)
+- `PEAR.php` throws a parse error on request (expected legacy code — will be addressed in later stages)
+- No database schema yet (we have no seed script in this stage — planned for later)
+
+**Files added in this stage:**
+- `Dockerfile`
+- `docker-compose.yml`
+- `docker/nginx/tuqan.conf`
+- `docker/php/php.ini`
+- `docker/php/xdebug.ini`
+- `.env.docker`
+- Updated `.gitignore`
+
+All work performed exclusively via Docker commands. No local PHP/nginx/postgres used.
 ```
 
 **Stage 2 — ...**

--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,4 @@
+# Tuqan Docker environment (Stage 1)
+DB_NAME=qnova
+DB_USER=qnova
+DB_PASS=change_me_in_real_use

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,13 @@ composer.lock
 /.idea/
 vendor
 .idea
+
+# Docker
+.env
+.env.local
+.env.*.local
+docker-compose.override.yml
+*.log
+
+# Keep the Docker template committed
+!.env.docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1.7
+FROM php:8.3-fpm-bookworm AS base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System packages + PHP extensions required by legacy Tuqan
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libpq-dev \
+        libgd-dev \
+        libzip-dev \
+        libicu-dev \
+        gettext \
+        locales \
+        unzip \
+        git \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) \
+        pdo \
+        pdo_pgsql \
+        pgsql \
+        gd \
+        zip \
+        gettext \
+        intl \
+        bcmath \
+        opcache \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Composer v2
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# Locale for gettext (matches original es_ES expectations)
+RUN sed -i '/es_ES.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+
+WORKDIR /var/www/html
+
+# -------------------------
+# Dev image (with Xdebug)
+# -------------------------
+FROM base AS dev
+
+RUN pecl install xdebug-3.3.2 \
+    && docker-php-ext-enable xdebug
+
+# Default dev php.ini overrides (also mounted)
+COPY docker/php/php.ini /usr/local/etc/php/conf.d/99-tuqan.ini
+COPY docker/php/xdebug.ini /usr/local/etc/php/conf.d/99-xdebug.ini
+
+# Non-root for bind mount friendliness on macOS
+RUN usermod -u 1000 www-data && groupmod -g 1000 www-data
+
+USER www-data
+
+# -------------------------
+# Prod image (lean, no xdebug)
+# -------------------------
+FROM base AS prod
+
+COPY docker/php/php.ini /usr/local/etc/php/conf.d/99-tuqan.ini
+
+RUN usermod -u 1000 www-data && groupmod -g 1000 www-data
+USER www-data
+
+# Default target for compose (override with --target prod later)
+FROM dev

--- a/Readme.md
+++ b/Readme.md
@@ -12,16 +12,15 @@ Modernization project of a PHP 5.1 application into modern PHP standards.
 
 ## Current Status (April 27, 2026)
 
-### ✅ Completed
+### ✅ Completed (Partial / Historical)
 - Composer setup with modern dependencies
 - Migration from PEAR::Auth to Jasny/Auth
-- PSR-4 autoloading structure (`Classes/`)
 - Routing implemented with Phroute
-- Forms migrated from PEAR::QuickForm to Former
-- Frontend updated to Bootstrap 5
-- Database layer fully migrated from PEAR::DB to PDO (see closed issue #21)
+- Forms migrated from PEAR::QuickForm to Former (in some areas)
+- Database layer migrated from PEAR::DB to PDO (see closed issue #21)
 - Gettext-based internationalization (`es_ES`)
-- Partial cleanup of old PEAR remnants
+
+**Note:** Some items above (e.g. full PSR-4 autoloading and Bootstrap 5) were listed in earlier status but are incomplete or inaccurate as of 2026. A full audit and Docker-based modernization effort is now underway.
 
 ### 🔄 In Progress
 - Complete removal of remaining PEAR dependencies
@@ -29,8 +28,40 @@ Modernization project of a PHP 5.1 application into modern PHP standards.
 - General code cleanup and modernization
 
 ### 🚧 Important Notes
-The application is **not functional**.  
-It is in an intermediate modernization state. Many legacy patterns still exist.
+**The application is NOT functional and is NOT production ready.**
+
+This is an ongoing modernization project of a very old codebase. It is currently in an intermediate state with significant legacy code, mixed concerns, and incomplete migrations.
+
+---
+
+## Development Environment (2026+)
+
+**All development must be done using Docker.** No local PHP, nginx, or PostgreSQL should be used.
+
+### Quick Start
+
+```bash
+# Start the full environment (PHP 8.3 + nginx + PostgreSQL)
+docker compose --env-file .env.docker up -d --build
+
+# Enter the PHP container
+docker compose exec app bash
+
+# Run composer
+docker compose exec app composer install
+
+# Check PHP version inside the container
+docker compose exec app php -v
+```
+
+The environment includes:
+- PHP 8.3.31 (FPM + CLI) with Xdebug
+- Nginx
+- PostgreSQL 16
+
+See `.agents/DOCKER-ENV.md` and `.agents/STAGE-CHECKLISTS.md` for full details and validation commands.
+
+**Note:** Stage 1 (Docker foundation) has been completed. Later stages will add a proper test harness and continue the modernization.
 
 ---
 
@@ -43,7 +74,7 @@ It is in an intermediate modernization state. Many legacy patterns still exist.
 | Authentication    | PEAR::Auth              | Jasny/Auth               | ✅ Done     |
 | Forms             | PEAR::QuickForm         | Former                   | ✅ Done     |
 | Routing           | Custom                  | Phroute                  | ✅ Done     |
-| Frontend          | Old HTML                | Bootstrap 5              | ✅ Done     |
+| Frontend          | Old HTML                | Bootstrap 3 (legacy)     | Partial     |
 | Localization      | Manual                  | gettext                  | ✅ Done     |
 
 ---
@@ -60,14 +91,28 @@ It is in an intermediate modernization state. Many legacy patterns still exist.
 
 ## How to Contribute / Work on the Project
 
+**All work must be done inside the Docker environment.**
+
 1. Clone the repository
-2. Run `composer install`
-3. Configure the database connection
-4. Test changes thoroughly before pushing
+2. Start the environment:
+   ```bash
+   docker compose --env-file .env.docker up -d --build
+   ```
+3. Install dependencies inside the container:
+   ```bash
+   docker compose exec app composer install
+   ```
+4. Make your changes (edit files locally — they are mounted into the container)
+5. Test your changes using Docker commands only
+6. Commit and open a Pull Request
 
 **Rule of thumb**: Every significant change should maintain or improve existing functionality.
 
+See `.agents/MIGRATION-PLAN.md` for the current modernization roadmap and `.agents/AGENTS.md` for contributor guidelines.
+
 ---
 
-Last updated: April 27, 2026  
+Last updated: May 2026  
 Maintained by laanito + agentic workflow
+
+> **Note**: A formal migration plan is being followed. See the documents in the `.agents/` directory for current status, Docker setup, and upcoming stages.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dev
+    volumes:
+      - .:/var/www/html
+      - ./docker/php/php.ini:/usr/local/etc/php/conf.d/99-tuqan.ini
+      - ./docker/php/xdebug.ini:/usr/local/etc/php/conf.d/99-xdebug.ini
+    environment:
+      - APP_ENV=dev
+      - DB_HOST=db
+      - DB_PORT=5432
+      - DB_NAME=${DB_NAME:-qnova}
+      - DB_USER=${DB_USER:-qnova}
+      - DB_PASS=${DB_PASS:-secret}
+    depends_on:
+      - db
+    networks:
+      - tuqan-net
+
+  web:
+    image: nginx:1.27-alpine
+    ports:
+      - "8080:80"
+    volumes:
+      - .:/var/www/html
+      - ./docker/nginx/tuqan.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - app
+    networks:
+      - tuqan-net
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_DB=${DB_NAME:-qnova}
+      - POSTGRES_USER=${DB_USER:-qnova}
+      - POSTGRES_PASSWORD=${DB_PASS:-secret}
+    volumes:
+      - tuqan_pgdata:/var/lib/postgresql/data
+    ports:
+      - "54321:5432"
+    networks:
+      - tuqan-net
+
+volumes:
+  tuqan_pgdata:
+
+networks:
+  tuqan-net:
+    driver: bridge

--- a/docker/nginx/tuqan.conf
+++ b/docker/nginx/tuqan.conf
@@ -1,0 +1,30 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /var/www/html;
+    index index.php index.html;
+
+    client_max_body_size 20M;
+
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+    }
+
+    location ~ \.php$ {
+        fastcgi_pass app:9000;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+        fastcgi_read_timeout 300;
+    }
+
+    # Legacy static paths
+    location ~* \.(jpg|jpeg|png|gif|ico|css|js|svg|ttf|woff)$ {
+        expires 30d;
+        access_log off;
+    }
+
+    location /userfiles/ {
+        alias /var/www/html/userfiles/;
+    }
+}

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -1,0 +1,27 @@
+; Tuqan legacy-friendly + modern dev settings
+memory_limit = 512M
+upload_max_filesize = 16M
+post_max_size = 20M
+max_execution_time = 300
+
+; Error reporting (strict in dev)
+error_reporting = E_ALL
+display_errors = On
+display_startup_errors = On
+log_errors = On
+error_log = /var/log/php_errors.log
+
+; Timezone (adjust to your needs)
+date.timezone = Europe/Madrid
+
+; OPcache (dev: validate timestamps)
+opcache.enable=1
+opcache.validate_timestamps=1
+opcache.revalidate_freq=0
+
+; Session (original uses $_SESSION heavily)
+session.save_handler = files
+session.save_path = /tmp
+
+; Legacy charset notes
+; Do not force UTF-8 globally yet — handle per connection in migration

--- a/docker/php/xdebug.ini
+++ b/docker/php/xdebug.ini
@@ -1,0 +1,7 @@
+zend_extension=xdebug.so
+xdebug.mode=develop,debug,coverage
+xdebug.start_with_request=yes
+xdebug.client_host=host.docker.internal
+xdebug.client_port=9003
+xdebug.log=/tmp/xdebug.log
+xdebug.discover_client_host=0


### PR DESCRIPTION
## Summary

This PR delivers **Stage 1** of the Tuqan PHP 8 + Docker migration plan: a fully isolated Docker development environment.

### Changes

- `Dockerfile` — PHP 8.3.31-fpm with dev/prod stages, Xdebug 3.3.2, all required extensions (pdo_pgsql, gd, gettext, intl, zip, etc.)
- `docker-compose.yml` — Services for `app`, `web` (nginx), and `db` (postgres 16)
- Supporting configs in `docker/nginx/` and `docker/php/`
- `.env.docker` template
- Updated `.gitignore` for Docker workflows
- `.agents/` documentation updated with full evidence for Stage 1

### Verification (all via Docker only)

- PHP 8.3.31 + Xdebug running inside container
- PostgreSQL 16 healthy
- Nginx + PHP-FPM responding on http://localhost:8080

No local PHP, nginx, or postgres instances were used.

### Next

Ready for review. Once merged, we can proceed to **Stage 2** (Testing Harness + PHP 8.3 baseline).

Refs: `.agents/MIGRATION-PLAN.md` and `.agents/STAGE-CHECKLISTS.md`