### PR TITLE
chore: add locale compilation scripts + Docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,17 @@ ENV LC_MESSAGES=es_ES.UTF-8
 
 WORKDIR /var/www/html
 
+# Install a small entrypoint that ensures .mo files are always up-to-date
+# from .po sources on every container start (very useful for dev + translations).
+# We place this in the base stage so both dev and prod images inherit the
+# ENTRYPOINT + the guarantee that locales are fresh.
+COPY docker/entrypoint.sh /usr/local/bin/tuqan-entrypoint.sh
+COPY scripts/compile-locales.sh /usr/local/bin/compile-locales.sh
+RUN chmod +x /usr/local/bin/tuqan-entrypoint.sh /usr/local/bin/compile-locales.sh
+
+ENTRYPOINT ["/usr/local/bin/tuqan-entrypoint.sh"]
+CMD ["php-fpm"]
+
 # -------------------------
 # Dev image (with Xdebug)
 # -------------------------

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# tuqan-entrypoint.sh
+#
+# Docker entrypoint for Tuqan.
+# Runs before the main CMD (php-fpm).
+#
+# Responsibilities:
+# - Ensure .mo files are freshly compiled from .po sources (so dev edits to
+#   translations take effect immediately, and prod images are always current).
+# - Then exec the original command so that signals, pid 1, etc. are handled
+#   correctly by php-fpm.
+#
+# The script is copied to /usr/local/bin/tuqan-entrypoint.sh and made executable
+# during the Docker build. Both the dev and prod stages inherit the ENTRYPOINT.
+
+set -e
+
+# Best-effort: do not prevent container from starting if compilation has a hiccup
+# (e.g. msgfmt not in PATH in some exotic image). The || true keeps us resilient.
+if [ -x /usr/local/bin/compile-locales.sh ]; then
+  /usr/local/bin/compile-locales.sh || true
+fi
+
+# Hand over to the real command (usually "php-fpm")
+exec "$@"

--- a/scripts/compile-locales.sh
+++ b/scripts/compile-locales.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# compile-locales.sh
+#
+# Recompiles gettext .po catalog files into .mo binary files.
+# Only recompiles when the .po is newer than the corresponding .mo (or .mo is missing).
+# This script is intended to be run on every container start via the Docker
+# entrypoint so that .po changes (especially during development) are automatically
+# reflected without requiring a manual msgfmt step or full image rebuild.
+#
+# Usage: ./scripts/compile-locales.sh   (or called from entrypoint)
+#
+# The textdomain used by the application is "qnova", therefore we always emit
+# qnova.mo inside each LC_MESSAGES directory.
+
+set -euo pipefail
+
+echo "[locale] Checking for .po -> .mo compilation needs..."
+
+shopt -s nullglob
+po_files=(Locale/*/LC_MESSAGES/*.po)
+
+if [ ${#po_files[@]} -eq 0 ]; then
+  echo "[locale] No .po files found under Locale/*/LC_MESSAGES/"
+  exit 0
+fi
+
+compiled=0
+for po_file in "${po_files[@]}"; do
+  mo_dir="$(dirname "$po_file")"
+  # Always target qnova.mo because that is the domain name used by bindtextdomain/textdomain in the app
+  mo_file="$mo_dir/qnova.mo"
+
+  if [ ! -f "$mo_file" ] || [ "$po_file" -nt "$mo_file" ]; then
+    echo "[locale] Compiling $po_file -> $mo_file"
+    mkdir -p "$mo_dir"
+    msgfmt --output-file="$mo_file" "$po_file"
+    compiled=$((compiled + 1))
+  fi
+done
+
+if [ "$compiled" -gt 0 ]; then
+  echo "[locale] Compiled $compiled catalog(s)."
+else
+  echo "[locale] All .mo files are up to date."
+fi


### PR DESCRIPTION
This small follow-up PR adds the scripts and Docker wiring that were left untracked on the `feat/stage-8.5-profiles-empresas-personalizacion` branch (PR #62, now merged).

### Changes
- `scripts/compile-locales.sh`: Finds all `Locale/*/LC_MESSAGES/*.po` and runs `msgfmt` to produce `qnova.mo` (the textdomain used by the app) **only** when the `.po` is newer than the `.mo` or the `.mo` is missing. Safe/idempotent for both dev and CI.
- `docker/entrypoint.sh`: Runs the compiler (best effort, `|| true`) then `exec "$@"`. This ensures fresh `.mo` files on every container start without manual intervention.
- `Dockerfile`: Inserts the `COPY`, `RUN chmod +x`, `ENTRYPOINT`, and `CMD` in the `base` stage (after `WORKDIR`). Both the `dev` and `prod` images now inherit the behavior automatically.

This completes the explicit request from the previous leg: "I think regenerating .mo files should be part of docker build".

The `docker/db-init/README.md` already referenced the feature; these files make the documented behavior actually present in the repo.

**Diff**: +83 lines (3 files). Very small, focused chore.

Branch was created fresh from `master` post-merge before any further work.

Ready for review ✅