### PR TITLE
feat: Stage 8.8 — finish last 2 Personalizacion modules (TiposAmb/TiposImp) + Tipo Cursos + 0016 patch + routes + verify/docs

### DIFF
--- a/.agents/MIGRATION-PLAN.md
+++ b/.agents/MIGRATION-PLAN.md
@@ -431,7 +431,8 @@ This phase is explicitly positioned as **pre-requisite infrastructure** before S
 - Stage 8.4 (Full menu structure reference + first real module "Administración → Usuarios"): Completed (PR #60)
 - Stage 8.5 (Perfiles + Empresas + Menus/Idiomas/Permisos under Aplicacion + menu UX + Docker locale handling): Completed on `feat/stage-8.5-profiles-empresas-personalizacion`.
 - Stage 8.6 (completed in PR #64 + #65): POST + validation for Perfiles + Sedes/Usuarios/Clientes/Criterios, Sedes rename, basic Permisos matrix, Menus editing, centralized flashes, testing strategy playbook + verify-8.6.sh + CI integration. Branch `feat/stage-8.6-post-handling-sedes-modules`.
-- Stage 8.7 (in progress): Complete remaining Personalizacion modules (3 full: Tipos Acc. Mejora, Tipos Area, Tipo Documento + placeholders for last 2), enhance Permisos matrix and Menus editing, new patches 0015+, extended verify + 8.7 playbook, all docs. Branch `feat/stage-8.7-personalizacion-complete-enhanced-tools`. Sized similarly to 8.6.
+- Stage 8.7 (completed in PR #66): Complete remaining Personalizacion modules (3 full: Tipos Acc. Mejora / tipoaccionesmejora, Tipos Area / tiposareas, Tipo Documento / tipodocumento), enhance Permisos matrix and Menus editing, new patches 0015+, extended verify + 8.7 playbook, all docs. Branch `feat/stage-8.7-personalizacion-complete-enhanced-tools`. Sized similarly to 8.6.
+- Stage 8.8 (in progress): Finish the last 2 Personalizacion modules from the original 7 (T. Amb. Aplicable / tiposamb + Tipos Imp. Amb. / tiposimp, replacing final Placeholders) + Tipo Cursos for volume parity (3 full modules total), patch 0016, full modern pages + routes + verify extension + 8.8 playbook + docs. Branch `feat/stage-8.8-finish-personalizacion-remaining-modules`. No enhancements; follow established pattern and testing strategy.
 - Stage 9+: Remaining deep logic, more sections, maturing automated tests + agentic loop (checklist-driven implement/verify/push/merge with reviewer subagent).
 
 **Buffer:** 2-4 weeks for surprises (legacy surprises always appear).
@@ -470,7 +471,7 @@ After each stage gate, append a "Stage N — Completed Evidence" section to this
 ---
 
 **Plan Owner:** This session's agent + future agents following AGENTS.md  
-**Last Updated:** 2026-06 (Stage 8.7 started on `feat/stage-8.7-personalizacion-complete-enhanced-tools` — completing remaining Personalizacion + enhancements to matrix/menus + verification playbook extension. Post #65).
+**Last Updated:** 2026-06 (Stage 8.8 started on `feat/stage-8.8-finish-personalizacion-remaining-modules` — finishing the last 2 Personalizacion (ex-Placeholders) + Tipo Cursos (3 modules total), 0016 patch, routes, verify/docs. 8.7 marked complete post #66. Post #67 blog).
 
 **Testing note (added after the big 8.6 merge):** See the new top section in .agents/STAGE-CHECKLISTS.md titled "Testing Strategy for Modernized Functional Modules". In short: for these vertical slices we rely on (1) rigorous, copy-pasteable Docker + psql verification commands + DB state assertions, (2) the human requester doing a full browser pass, and (3) whatever stable automated tests exist. Pure unit/integration coverage for the new `Procesar` methods and UIs is still catching up because of the current shape of the page classes. The checklists are the contract for "how do we know this actually works".
 **Approval Status:** Stage 8.3 plan reviewed and approved by user (menu "as-is" first; Former deferred until form pages are reached)

--- a/.agents/STAGE-CHECKLISTS.md
+++ b/.agents/STAGE-CHECKLISTS.md
@@ -1449,12 +1449,79 @@ docker compose exec db psql -U qnova -d qnova -c "SELECT ... FROM tiposmejora ..
 - data_patches has the new ones.
 
 **Next in this or follow-up legs (from plan):**
-- Remaining 2 Personalizacion if not fully done.
+- (Completed in 8.7) Remaining 2 Personalizacion if not fully done — see Stage 8.8.
 - Even deeper (full search? other sections?).
 - More extraction of logic for real unit tests.
 - Expand the agentic loop ideas from the article (using checklist as queue, reviewer subagent).
 
-**Branch status:** In progress. Will follow the detailed plan in reference/stage-8.7-....md. All via Docker, using the testing strategy.
+**Branch status:** Completed (merged as part of #66). Evidence and verification playbook in prior section. Follow-up work (finishing the exact "remaining 2" + similar volume) moved to Stage 8.8 on `feat/stage-8.8-finish-personalizacion-remaining-modules`.
+
+---
+
+**Next steps after this stage playbook is solid:**
+- Continue the pattern: more modules or deeper business logic (e.g. full under other branches).
+- Mature automated tests as more logic is isolated from the page classes.
+- Use the verification playbooks as the basis for future agentic loops (as discussed in the related praderasblog article).
+
+## Stage 8.8 — Finish Remaining Personalización Modules + Tipo Cursos
+
+**Branch:** `feat/stage-8.8-finish-personalizacion-remaining-modules`
+
+**Goal:** Finish the last 2 items from the original 7 Personalizacion modules (T. Amb. Aplicable / tiposamb and Tipos Imp. Amb. / tiposimp — previously left on Placeholder per 8.7 scope decision), deliver one additional similar catalog module (Tipo Cursos) to keep change size similar to 8.6/8.7, provide full modern Listado + Formulario + Procesar (POST/validation/flash), extend the verify script and playbook, update all docs. No scope creep.
+
+**Selected scope for this leg (chosen from the plan and previous follow-up notes):**
+- 3 full modules with GET+POST (Tipos Amb. Aplicable, Tipos Imp. Amb., Tipo Cursos), modeled exactly on TiposMejora/TiposAreas/TipoDocumento (and earlier catalog modules).
+- New patch 0016 for the 3 lightweight tables + demo seeds + data_patches tracking (no menu inserts needed; accions pre-exist).
+- Full routes (modern /admin/* + legacy /administracion/* paths from menu accions) replacing the last 2 Placeholders.
+- Extend verify-8.6.sh (php -l + DB asserts) + full "Stage 8.8 Verification Playbook".
+- Docs: new section here, update MIGRATION-PLAN, db-init/README.
+- Kept reasonable: exactly 3 modules, no child menu entries added (consistent with 8.7 choice), follow current testing strategy.
+
+**Key changes (planned and executed):**
+- New data patch: 0016-personalizacion-last-two-plus-tipocursos.sql (tables tiposamb, tiposimp, tipocursos + seeds + patch record).
+- 3 new module dirs: Pages/{TiposAmb,TiposImp,TipoCursos}/ + templates/ + full Listado/Formulario with Procesar (copy of 8.7 pattern, module flash keys, Manejador + preparada).
+- index.php: full modern routes for the 3 (incl. /nuevo /editar/{id} + POST), legacy ver paths, removal of the 2 Placeholder lines, updated comments.
+- scripts/verify-8.6.sh extended (header, php -l list, table list, union counts, patch filter).
+- Full verification playbook section (modeled on 8.7).
+- Docs updates in .agents/ + docker/db-init/README.md.
+- First commit on branch: the detailed plan (reference/stage-8.8-...-plan.md).
+
+**Evidence (commands run inside containers — expanded during execution):**
+```bash
+# Branch / plan
+git checkout -b feat/stage-8.8-... && git add reference/stage-8.8-...-plan.md && git commit -m "docs: add detailed plan for Stage 8.8..."
+
+# Patch + apply (or via init)
+docker compose exec -e PGPASSWORD=secret app psql -h db -U qnova -d qnova -v ON_ERROR_STOP=1 -f /var/www/html/docker/db-init/data-patches/0016-....sql
+
+# Syntax
+docker compose exec app php -l Pages/TiposAmb/Listado.php ... Pages/TipoCursos/Formulario.php index.php
+
+# Full non-interactive
+docker compose exec app ./scripts/verify-8.6.sh
+
+# DB asserts (tables, counts, patch, menu accions for the 3)
+docker compose exec -e PGPASSWORD=secret app psql -h db -U qnova -d qnova -c "
+  SELECT tablename FROM pg_tables WHERE ... IN ('tiposamb',...);
+  SELECT 'tiposamb', COUNT(*) FROM tiposamb UNION ... ;
+  SELECT filename FROM data_patches WHERE filename LIKE '0016%';
+  SELECT id, accion FROM menu_nuevo WHERE accion LIKE '%tiposamb%' OR ... ;
+"
+```
+
+**DB verification after patches (example gates):**
+- New tables (tiposamb, tiposimp, tipocursos) exist with seeded rows (4/3/4 in 0016).
+- data_patches has the 0016 filename.
+- Menu accions/labels for the items remain correct (pre-existing).
+- After create/edit: new/updated row visible in psql and list.
+
+**Next in this or follow-up legs (from plan):**
+- Remaining 2 Personalizacion completed (plus Tipo Cursos for volume).
+- Even deeper (full search? other sections under Administracion / Calidad / etc.?).
+- More extraction of logic for real unit tests (page classes still script-like).
+- Expand the agentic loop (checklist -> implement -> verify/playbook -> subagent QA -> push/PR).
+
+**Branch status:** In progress on `feat/stage-8.8-finish-personalizacion-remaining-modules`. Will follow the detailed plan in reference/stage-8.8-finish-personalizacion-remaining-modules.md. All via Docker, using the testing strategy. (Plan committed as first commit on branch.)
 
 ---
 

--- a/Pages/TipoCursos/Formulario.php
+++ b/Pages/TipoCursos/Formulario.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tuqan\Pages\TipoCursos;
+
+use Tuqan\Classes\Config;
+use Twig\Loader\FilesystemLoader;
+use Twig\Environment;
+
+class Formulario
+{
+    public function ShowPage($id = null)
+    {
+        Config::initialize();
+
+        $loader = new FilesystemLoader(Config::$template_path);
+        $twig = new Environment($loader, [
+            'cache' => Config::$cache_path,
+        ]);
+
+        $mainPage = new \Tuqan\Pages\MainPage();
+        $sidebarMenu = $mainPage->buildSidebarMenuHtml();
+
+        if ($id === null && isset($_GET['id'])) {
+            $id = (int)$_GET['id'];
+        }
+        $id = (int)$id;
+        $tipocursos = null;
+
+        if ($id > 0) {
+            $host = $_SESSION['db_host'] ?? (getenv('DB_HOST') ?: 'localhost');
+            $port = $_SESSION['db_port'] ?? (int)(getenv('DB_PORT') ?: 5432);
+
+            $db = new \Tuqan\Classes\Manejador_Base_Datos(
+                $_SESSION['login'] ?? '',
+                $_SESSION['pass'] ?? '',
+                $_SESSION['db'] ?? '',
+                $host,
+                $port
+            );
+
+            $db->consultaPreparada(
+                "SELECT id, nombre, activo FROM tipocursos WHERE id = ?",
+                [$id]
+            );
+            $row = $db->coger_Fila();
+            if ($row) {
+                $tipocursos = [
+                    'id'     => $row[0],
+                    'nombre' => $row[1],
+                    'activo' => $row[2],
+                ];
+            }
+            $db->desconexion();
+        }
+
+        $fullName = trim(($_SESSION['usuario_nombre'] ?? '') . ' ' . ($_SESSION['usuario_apellido'] ?? ''));
+
+        $variables = [
+            'sidebarMenu' => $sidebarMenu,
+            'tipocursos'  => $tipocursos,
+            'isEdit'      => (bool)$tipocursos,
+            'pageTitle'   => $tipocursos ? 'Editar Tipo Cursos' : 'Nuevo Tipo Cursos',
+            'UserTitle'     => gettext('sUsuario'),
+            'UserName'      => $_SESSION['nombreUsuario'] ?? 'Guest',
+            'CompanyName'   => $_SESSION['empresa'] ?? null,
+            'UserEmail'     => $_SESSION['usuario_email'] ?? null,
+            'UserFullName'  => $fullName ?: ($_SESSION['nombreUsuario'] ?? 'Guest'),
+        ];
+
+        try {
+            $template = $twig->load('tipocursos/formulario.twig');
+            return $template->render($variables);
+        } catch (\Exception $e) {
+            return "Error al cargar el formulario de Tipo Cursos: " . $e->getMessage();
+        }
+    }
+
+    public function Procesar($id = null)
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            header('Location: /admin/tipo-cursos');
+            exit;
+        }
+
+        Config::initialize();
+
+        if ($id === null) {
+            $id = isset($_POST['id']) ? (int)$_POST['id'] : (isset($_GET['id']) ? (int)$_GET['id'] : null);
+        }
+        $id = (int)$id;
+
+        $nombre = trim($_POST['nombre'] ?? '');
+        $activo = !empty($_POST['activo']) ? 1 : 0;
+
+        $errors = [];
+        if ($nombre === '') {
+            $errors[] = 'El nombre es obligatorio.';
+        }
+
+        if (!empty($errors)) {
+            $_SESSION['tipocursos_form_error'] = implode(' ', $errors);
+            $target = $id > 0 ? "/admin/tipo-cursos/editar/$id" : '/admin/tipo-cursos/nuevo';
+            header("Location: $target");
+            exit;
+        }
+
+        $host = $_SESSION['db_host'] ?? (getenv('DB_HOST') ?: 'localhost');
+        $port = $_SESSION['db_port'] ?? (int)(getenv('DB_PORT') ?: 5432);
+
+        $db = new \Tuqan\Classes\Manejador_Base_Datos(
+            $_SESSION['login'] ?? '',
+            $_SESSION['pass'] ?? '',
+            $_SESSION['db'] ?? '',
+            $host,
+            $port
+        );
+
+        if ($id > 0) {
+            $db->consultaPreparada(
+                "UPDATE tipocursos SET nombre = ?, activo = ? WHERE id = ?",
+                [$nombre, $activo, $id]
+            );
+            $msg = 'Tipo Cursos actualizado correctamente.';
+        } else {
+            $db->consultaPreparada(
+                "INSERT INTO tipocursos (nombre, activo) VALUES (?, ?)",
+                [$nombre, $activo]
+            );
+            $msg = 'Tipo Cursos creado correctamente.';
+        }
+
+        $db->desconexion();
+
+        $_SESSION['tipocursos_flash_success'] = $msg;
+        header('Location: /admin/tipo-cursos');
+        exit;
+    }
+}

--- a/Pages/TipoCursos/Listado.php
+++ b/Pages/TipoCursos/Listado.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tuqan\Pages\TipoCursos;
+
+use Tuqan\Classes\Config;
+use Twig\Loader\FilesystemLoader;
+use Twig\Environment;
+
+class Listado
+{
+    public function ShowPage()
+    {
+        Config::initialize();
+
+        $loader = new FilesystemLoader(Config::$template_path);
+        $twig = new Environment($loader, [
+            'cache' => Config::$cache_path,
+        ]);
+
+        $mainPage = new \Tuqan\Pages\MainPage();
+        $sidebarMenu = $mainPage->buildSidebarMenuHtml();
+
+        $host = $_SESSION['db_host'] ?? (getenv('DB_HOST') ?: 'localhost');
+        $port = $_SESSION['db_port'] ?? (int)(getenv('DB_PORT') ?: 5432);
+
+        $db = new \Tuqan\Classes\Manejador_Base_Datos(
+            $_SESSION['login'] ?? '',
+            $_SESSION['pass'] ?? '',
+            $_SESSION['db'] ?? '',
+            $host,
+            $port
+        );
+
+        $db->consulta("SELECT id, nombre, activo FROM tipocursos ORDER BY id");
+
+        $tipocursos = [];
+        while ($row = $db->coger_Fila()) {
+            $tipocursos[] = [
+                'id'     => $row[0],
+                'nombre' => $row[1],
+                'activo' => $row[2],
+            ];
+        }
+        $db->desconexion();
+
+        $fullName = trim(($_SESSION['usuario_nombre'] ?? '') . ' ' . ($_SESSION['usuario_apellido'] ?? ''));
+
+        $flashSuccess = $_SESSION['tipocursos_flash_success'] ?? null;
+        $flashError   = $_SESSION['tipocursos_form_error'] ?? null;
+        unset($_SESSION['tipocursos_flash_success'], $_SESSION['tipocursos_form_error']);
+
+        $variables = [
+            'sidebarMenu'   => $sidebarMenu,
+            'tipocursos'    => $tipocursos,
+            'pageTitle'     => 'Tipo Cursos',
+            'flashSuccess'  => $flashSuccess,
+            'flashError'    => $flashError,
+            'UserTitle'     => gettext('sUsuario'),
+            'UserName'      => $_SESSION['nombreUsuario'] ?? 'Guest',
+            'CompanyName'   => $_SESSION['empresa'] ?? null,
+            'UserEmail'     => $_SESSION['usuario_email'] ?? null,
+            'UserFullName'  => $fullName ?: ($_SESSION['nombreUsuario'] ?? 'Guest'),
+        ];
+
+        try {
+            $template = $twig->load('tipocursos/listado.twig');
+            return $template->render($variables);
+        } catch (\Exception $e) {
+            return "Error al cargar Tipo Cursos: " . $e->getMessage();
+        }
+    }
+}

--- a/Pages/TiposAmb/Formulario.php
+++ b/Pages/TiposAmb/Formulario.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tuqan\Pages\TiposAmb;
+
+use Tuqan\Classes\Config;
+use Twig\Loader\FilesystemLoader;
+use Twig\Environment;
+
+class Formulario
+{
+    public function ShowPage($id = null)
+    {
+        Config::initialize();
+
+        $loader = new FilesystemLoader(Config::$template_path);
+        $twig = new Environment($loader, [
+            'cache' => Config::$cache_path,
+        ]);
+
+        $mainPage = new \Tuqan\Pages\MainPage();
+        $sidebarMenu = $mainPage->buildSidebarMenuHtml();
+
+        if ($id === null && isset($_GET['id'])) {
+            $id = (int)$_GET['id'];
+        }
+        $id = (int)$id;
+        $tiposamb = null;
+
+        if ($id > 0) {
+            $host = $_SESSION['db_host'] ?? (getenv('DB_HOST') ?: 'localhost');
+            $port = $_SESSION['db_port'] ?? (int)(getenv('DB_PORT') ?: 5432);
+
+            $db = new \Tuqan\Classes\Manejador_Base_Datos(
+                $_SESSION['login'] ?? '',
+                $_SESSION['pass'] ?? '',
+                $_SESSION['db'] ?? '',
+                $host,
+                $port
+            );
+
+            $db->consultaPreparada(
+                "SELECT id, nombre, activo FROM tiposamb WHERE id = ?",
+                [$id]
+            );
+            $row = $db->coger_Fila();
+            if ($row) {
+                $tiposamb = [
+                    'id'     => $row[0],
+                    'nombre' => $row[1],
+                    'activo' => $row[2],
+                ];
+            }
+            $db->desconexion();
+        }
+
+        $fullName = trim(($_SESSION['usuario_nombre'] ?? '') . ' ' . ($_SESSION['usuario_apellido'] ?? ''));
+
+        $variables = [
+            'sidebarMenu' => $sidebarMenu,
+            'tiposamb'    => $tiposamb,
+            'isEdit'      => (bool)$tiposamb,
+            'pageTitle'   => $tiposamb ? 'Editar Tipo Amb. Aplicable' : 'Nuevo Tipo Amb. Aplicable',
+            'UserTitle'     => gettext('sUsuario'),
+            'UserName'      => $_SESSION['nombreUsuario'] ?? 'Guest',
+            'CompanyName'   => $_SESSION['empresa'] ?? null,
+            'UserEmail'     => $_SESSION['usuario_email'] ?? null,
+            'UserFullName'  => $fullName ?: ($_SESSION['nombreUsuario'] ?? 'Guest'),
+        ];
+
+        try {
+            $template = $twig->load('tiposamb/formulario.twig');
+            return $template->render($variables);
+        } catch (\Exception $e) {
+            return "Error al cargar el formulario de Tipos Amb. Aplicable: " . $e->getMessage();
+        }
+    }
+
+    public function Procesar($id = null)
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            header('Location: /admin/tiposamb');
+            exit;
+        }
+
+        Config::initialize();
+
+        if ($id === null) {
+            $id = isset($_POST['id']) ? (int)$_POST['id'] : (isset($_GET['id']) ? (int)$_GET['id'] : null);
+        }
+        $id = (int)$id;
+
+        $nombre = trim($_POST['nombre'] ?? '');
+        $activo = !empty($_POST['activo']) ? 1 : 0;
+
+        $errors = [];
+        if ($nombre === '') {
+            $errors[] = 'El nombre es obligatorio.';
+        }
+
+        if (!empty($errors)) {
+            $_SESSION['tiposamb_form_error'] = implode(' ', $errors);
+            $target = $id > 0 ? "/admin/tiposamb/editar/$id" : '/admin/tiposamb/nuevo';
+            header("Location: $target");
+            exit;
+        }
+
+        $host = $_SESSION['db_host'] ?? (getenv('DB_HOST') ?: 'localhost');
+        $port = $_SESSION['db_port'] ?? (int)(getenv('DB_PORT') ?: 5432);
+
+        $db = new \Tuqan\Classes\Manejador_Base_Datos(
+            $_SESSION['login'] ?? '',
+            $_SESSION['pass'] ?? '',
+            $_SESSION['db'] ?? '',
+            $host,
+            $port
+        );
+
+        if ($id > 0) {
+            $db->consultaPreparada(
+                "UPDATE tiposamb SET nombre = ?, activo = ? WHERE id = ?",
+                [$nombre, $activo, $id]
+            );
+            $msg = 'Tipo Amb. Aplicable actualizado correctamente.';
+        } else {
+            $db->consultaPreparada(
+                "INSERT INTO tiposamb (nombre, activo) VALUES (?, ?)",
+                [$nombre, $activo]
+            );
+            $msg = 'Tipo Amb. Aplicable creado correctamente.';
+        }
+
+        $db->desconexion();
+
+        $_SESSION['tiposamb_flash_success'] = $msg;
+        header('Location: /admin/tiposamb');
+        exit;
+    }
+}

--- a/Pages/TiposAmb/Listado.php
+++ b/Pages/TiposAmb/Listado.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tuqan\Pages\TiposAmb;
+
+use Tuqan\Classes\Config;
+use Twig\Loader\FilesystemLoader;
+use Twig\Environment;
+
+class Listado
+{
+    public function ShowPage()
+    {
+        Config::initialize();
+
+        $loader = new FilesystemLoader(Config::$template_path);
+        $twig = new Environment($loader, [
+            'cache' => Config::$cache_path,
+        ]);
+
+        $mainPage = new \Tuqan\Pages\MainPage();
+        $sidebarMenu = $mainPage->buildSidebarMenuHtml();
+
+        $host = $_SESSION['db_host'] ?? (getenv('DB_HOST') ?: 'localhost');
+        $port = $_SESSION['db_port'] ?? (int)(getenv('DB_PORT') ?: 5432);
+
+        $db = new \Tuqan\Classes\Manejador_Base_Datos(
+            $_SESSION['login'] ?? '',
+            $_SESSION['pass'] ?? '',
+            $_SESSION['db'] ?? '',
+            $host,
+            $port
+        );
+
+        $db->consulta("SELECT id, nombre, activo FROM tiposamb ORDER BY id");
+
+        $tiposamb = [];
+        while ($row = $db->coger_Fila()) {
+            $tiposamb[] = [
+                'id'     => $row[0],
+                'nombre' => $row[1],
+                'activo' => $row[2],
+            ];
+        }
+        $db->desconexion();
+
+        $fullName = trim(($_SESSION['usuario_nombre'] ?? '') . ' ' . ($_SESSION['usuario_apellido'] ?? ''));
+
+        $flashSuccess = $_SESSION['tiposamb_flash_success'] ?? null;
+        $flashError   = $_SESSION['tiposamb_form_error'] ?? null;
+        unset($_SESSION['tiposamb_flash_success'], $_SESSION['tiposamb_form_error']);
+
+        $variables = [
+            'sidebarMenu'   => $sidebarMenu,
+            'tiposamb'      => $tiposamb,
+            'pageTitle'     => 'Tipos Amb. Aplicable',
+            'flashSuccess'  => $flashSuccess,
+            'flashError'    => $flashError,
+            'UserTitle'     => gettext('sUsuario'),
+            'UserName'      => $_SESSION['nombreUsuario'] ?? 'Guest',
+            'CompanyName'   => $_SESSION['empresa'] ?? null,
+            'UserEmail'     => $_SESSION['usuario_email'] ?? null,
+            'UserFullName'  => $fullName ?: ($_SESSION['nombreUsuario'] ?? 'Guest'),
+        ];
+
+        try {
+            $template = $twig->load('tiposamb/listado.twig');
+            return $template->render($variables);
+        } catch (\Exception $e) {
+            return "Error al cargar Tipos Amb. Aplicable: " . $e->getMessage();
+        }
+    }
+}

--- a/Pages/TiposImp/Formulario.php
+++ b/Pages/TiposImp/Formulario.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tuqan\Pages\TiposImp;
+
+use Tuqan\Classes\Config;
+use Twig\Loader\FilesystemLoader;
+use Twig\Environment;
+
+class Formulario
+{
+    public function ShowPage($id = null)
+    {
+        Config::initialize();
+
+        $loader = new FilesystemLoader(Config::$template_path);
+        $twig = new Environment($loader, [
+            'cache' => Config::$cache_path,
+        ]);
+
+        $mainPage = new \Tuqan\Pages\MainPage();
+        $sidebarMenu = $mainPage->buildSidebarMenuHtml();
+
+        if ($id === null && isset($_GET['id'])) {
+            $id = (int)$_GET['id'];
+        }
+        $id = (int)$id;
+        $tiposimp = null;
+
+        if ($id > 0) {
+            $host = $_SESSION['db_host'] ?? (getenv('DB_HOST') ?: 'localhost');
+            $port = $_SESSION['db_port'] ?? (int)(getenv('DB_PORT') ?: 5432);
+
+            $db = new \Tuqan\Classes\Manejador_Base_Datos(
+                $_SESSION['login'] ?? '',
+                $_SESSION['pass'] ?? '',
+                $_SESSION['db'] ?? '',
+                $host,
+                $port
+            );
+
+            $db->consultaPreparada(
+                "SELECT id, nombre, activo FROM tiposimp WHERE id = ?",
+                [$id]
+            );
+            $row = $db->coger_Fila();
+            if ($row) {
+                $tiposimp = [
+                    'id'     => $row[0],
+                    'nombre' => $row[1],
+                    'activo' => $row[2],
+                ];
+            }
+            $db->desconexion();
+        }
+
+        $fullName = trim(($_SESSION['usuario_nombre'] ?? '') . ' ' . ($_SESSION['usuario_apellido'] ?? ''));
+
+        $variables = [
+            'sidebarMenu' => $sidebarMenu,
+            'tiposimp'    => $tiposimp,
+            'isEdit'      => (bool)$tiposimp,
+            'pageTitle'   => $tiposimp ? 'Editar Tipo Imp. Amb.' : 'Nuevo Tipo Imp. Amb.',
+            'UserTitle'     => gettext('sUsuario'),
+            'UserName'      => $_SESSION['nombreUsuario'] ?? 'Guest',
+            'CompanyName'   => $_SESSION['empresa'] ?? null,
+            'UserEmail'     => $_SESSION['usuario_email'] ?? null,
+            'UserFullName'  => $fullName ?: ($_SESSION['nombreUsuario'] ?? 'Guest'),
+        ];
+
+        try {
+            $template = $twig->load('tiposimp/formulario.twig');
+            return $template->render($variables);
+        } catch (\Exception $e) {
+            return "Error al cargar el formulario de Tipos Imp. Amb.: " . $e->getMessage();
+        }
+    }
+
+    public function Procesar($id = null)
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            header('Location: /admin/tiposimp');
+            exit;
+        }
+
+        Config::initialize();
+
+        if ($id === null) {
+            $id = isset($_POST['id']) ? (int)$_POST['id'] : (isset($_GET['id']) ? (int)$_GET['id'] : null);
+        }
+        $id = (int)$id;
+
+        $nombre = trim($_POST['nombre'] ?? '');
+        $activo = !empty($_POST['activo']) ? 1 : 0;
+
+        $errors = [];
+        if ($nombre === '') {
+            $errors[] = 'El nombre es obligatorio.';
+        }
+
+        if (!empty($errors)) {
+            $_SESSION['tiposimp_form_error'] = implode(' ', $errors);
+            $target = $id > 0 ? "/admin/tiposimp/editar/$id" : '/admin/tiposimp/nuevo';
+            header("Location: $target");
+            exit;
+        }
+
+        $host = $_SESSION['db_host'] ?? (getenv('DB_HOST') ?: 'localhost');
+        $port = $_SESSION['db_port'] ?? (int)(getenv('DB_PORT') ?: 5432);
+
+        $db = new \Tuqan\Classes\Manejador_Base_Datos(
+            $_SESSION['login'] ?? '',
+            $_SESSION['pass'] ?? '',
+            $_SESSION['db'] ?? '',
+            $host,
+            $port
+        );
+
+        if ($id > 0) {
+            $db->consultaPreparada(
+                "UPDATE tiposimp SET nombre = ?, activo = ? WHERE id = ?",
+                [$nombre, $activo, $id]
+            );
+            $msg = 'Tipo Imp. Amb. actualizado correctamente.';
+        } else {
+            $db->consultaPreparada(
+                "INSERT INTO tiposimp (nombre, activo) VALUES (?, ?)",
+                [$nombre, $activo]
+            );
+            $msg = 'Tipo Imp. Amb. creado correctamente.';
+        }
+
+        $db->desconexion();
+
+        $_SESSION['tiposimp_flash_success'] = $msg;
+        header('Location: /admin/tiposimp');
+        exit;
+    }
+}

--- a/Pages/TiposImp/Listado.php
+++ b/Pages/TiposImp/Listado.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tuqan\Pages\TiposImp;
+
+use Tuqan\Classes\Config;
+use Twig\Loader\FilesystemLoader;
+use Twig\Environment;
+
+class Listado
+{
+    public function ShowPage()
+    {
+        Config::initialize();
+
+        $loader = new FilesystemLoader(Config::$template_path);
+        $twig = new Environment($loader, [
+            'cache' => Config::$cache_path,
+        ]);
+
+        $mainPage = new \Tuqan\Pages\MainPage();
+        $sidebarMenu = $mainPage->buildSidebarMenuHtml();
+
+        $host = $_SESSION['db_host'] ?? (getenv('DB_HOST') ?: 'localhost');
+        $port = $_SESSION['db_port'] ?? (int)(getenv('DB_PORT') ?: 5432);
+
+        $db = new \Tuqan\Classes\Manejador_Base_Datos(
+            $_SESSION['login'] ?? '',
+            $_SESSION['pass'] ?? '',
+            $_SESSION['db'] ?? '',
+            $host,
+            $port
+        );
+
+        $db->consulta("SELECT id, nombre, activo FROM tiposimp ORDER BY id");
+
+        $tiposimp = [];
+        while ($row = $db->coger_Fila()) {
+            $tiposimp[] = [
+                'id'     => $row[0],
+                'nombre' => $row[1],
+                'activo' => $row[2],
+            ];
+        }
+        $db->desconexion();
+
+        $fullName = trim(($_SESSION['usuario_nombre'] ?? '') . ' ' . ($_SESSION['usuario_apellido'] ?? ''));
+
+        $flashSuccess = $_SESSION['tiposimp_flash_success'] ?? null;
+        $flashError   = $_SESSION['tiposimp_form_error'] ?? null;
+        unset($_SESSION['tiposimp_flash_success'], $_SESSION['tiposimp_form_error']);
+
+        $variables = [
+            'sidebarMenu'   => $sidebarMenu,
+            'tiposimp'      => $tiposimp,
+            'pageTitle'     => 'Tipos Imp. Amb.',
+            'flashSuccess'  => $flashSuccess,
+            'flashError'    => $flashError,
+            'UserTitle'     => gettext('sUsuario'),
+            'UserName'      => $_SESSION['nombreUsuario'] ?? 'Guest',
+            'CompanyName'   => $_SESSION['empresa'] ?? null,
+            'UserEmail'     => $_SESSION['usuario_email'] ?? null,
+            'UserFullName'  => $fullName ?: ($_SESSION['nombreUsuario'] ?? 'Guest'),
+        ];
+
+        try {
+            $template = $twig->load('tiposimp/listado.twig');
+            return $template->render($variables);
+        } catch (\Exception $e) {
+            return "Error al cargar Tipos Imp. Amb.: " . $e->getMessage();
+        }
+    }
+}

--- a/docker/db-init/README.md
+++ b/docker/db-init/README.md
@@ -67,6 +67,7 @@ data-patches/
   0013-clientes-table-and-seed.sql                      -- Stage 8.6: first Personalizacion module
   0014-more-personalizacion-modules.sql                 -- Stage 8.6: Criterios + tiposmejora
   0015-... (Stage 8.7): tables for Tipos Acc. Mejora, Tipos Area, Tipo Documento + seeds + menu actions
+  0016-personalizacion-last-two-plus-tipocursos.sql     -- Stage 8.8: tables+seeds for last 2 Personalizacion (tiposamb, tiposimp) + Tipo Cursos
   ...
 ```
 

--- a/docker/db-init/data-patches/0016-personalizacion-last-two-plus-tipocursos.sql
+++ b/docker/db-init/data-patches/0016-personalizacion-last-two-plus-tipocursos.sql
@@ -1,0 +1,59 @@
+-- 0016-personalizacion-last-two-plus-tipocursos.sql
+-- Stage 8.8: tables + seeds for the last 2 Personalizacion modules from the original 7
+-- (T. Amb. Aplicable / tiposamb + Tipos Imp. Amb. / tiposimp) plus Tipo Cursos (tipocursos)
+-- to keep PR size similar to 8.6/8.7 while finishing the Aplicacion/Personalizacion focus.
+-- Lightweight (id, nombre, activo) exactly like 0013/0014/0015.
+-- Idempotent (CREATE IF NOT EXISTS + INSERT ... ON CONFLICT DO NOTHING).
+-- No menu_nuevo changes needed: the leaf entries (administracion:tiposamb:listado:ver etc.)
+-- pre-exist from 0004 full legacy menu + 0010 restructure.
+
+-- Tipos Amb. Aplicable (T. Amb. Aplicacion)
+CREATE TABLE IF NOT EXISTS tiposamb (
+    id SERIAL PRIMARY KEY,
+    nombre TEXT NOT NULL,
+    activo BOOLEAN NOT NULL DEFAULT true
+);
+INSERT INTO tiposamb (nombre, activo)
+VALUES ('Ruido Demo', true),
+       ('Residuos Sólidos Demo', true),
+       ('Vertidos Demo', true),
+       ('Emisiones Demo', true)
+ON CONFLICT DO NOTHING;
+
+-- Tipos Imp. Amb.
+CREATE TABLE IF NOT EXISTS tiposimp (
+    id SERIAL PRIMARY KEY,
+    nombre TEXT NOT NULL,
+    activo BOOLEAN NOT NULL DEFAULT true
+);
+INSERT INTO tiposimp (nombre, activo)
+VALUES ('Impacto Ambiental Alto Demo', true),
+       ('Impacto Medio Demo', true),
+       ('Impacto Controlado Demo', true)
+ON CONFLICT DO NOTHING;
+
+-- Tipo Cursos (under Formacion area in menu; catalog like other tipos)
+CREATE TABLE IF NOT EXISTS tipocursos (
+    id SERIAL PRIMARY KEY,
+    nombre TEXT NOT NULL,
+    activo BOOLEAN NOT NULL DEFAULT true
+);
+INSERT INTO tipocursos (nombre, activo)
+VALUES ('Curso Calidad Demo', true),
+       ('Curso Ambiental Demo', true),
+       ('Curso Seguridad y Salud Demo', true),
+       ('Curso Gestión Demo', true)
+ON CONFLICT DO NOTHING;
+
+-- Record patch (guard inside patch + also in init-db.sh)
+INSERT INTO data_patches (filename, applied_at)
+VALUES ('0016-personalizacion-last-two-plus-tipocursos.sql', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMENT ON TABLE tiposamb IS 'Tipos Amb. Aplicable (Personalizacion, last of original 7). Lightweight for Stage 8.8.';
+COMMENT ON TABLE tiposimp IS 'Tipos Imp. Amb. (Personalizacion, last of original 7). Lightweight for Stage 8.8.';
+COMMENT ON TABLE tipocursos IS 'Tipo Cursos (catalog under Formacion). Lightweight for Stage 8.8.';
+
+-- Note: modern routes will be added for /admin/tiposamb , /admin/tiposimp , /admin/tipo-cursos
+-- plus legacy /administracion/... paths so menu clicks (resolveLegacyAction) land on real pages.
+-- Placeholder routes for the 2 will be replaced in index.php.

--- a/index.php
+++ b/index.php
@@ -286,9 +286,32 @@ $router->addRoute('POST', '/admin/tipo-documento/editar/{id}', ['Tuqan\Pages\Tip
 $router->addRoute('GET', '/administracion/tiposareas/listado/ver', ['Tuqan\Pages\TiposAreas\Listado', 'ShowPage'], ['before' => 'auth_company']);
 $router->addRoute('GET', '/administracion/tipodocumento/listado/nuevo', ['Tuqan\Pages\TipoDocumento\Listado', 'ShowPage'], ['before' => 'auth_company']);
 
-// Remaining 2 Personalizacion children still basic/Placeholder (incremental)
-$router->addRoute('GET', '/admin/tiposamb', ['Tuqan\Pages\Placeholder', 'ShowPage'], ['before' => 'auth_company']);
-$router->addRoute('GET', '/admin/tiposimp', ['Tuqan\Pages\Placeholder', 'ShowPage'], ['before' => 'auth_company']);
+// Stage 8.8: finish last 2 Personalizacion (tiposamb, tiposimp) + Tipo Cursos (full modern)
+$router->addRoute('GET', '/admin/tiposamb', ['Tuqan\Pages\TiposAmb\Listado', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/tiposamb/nuevo', ['Tuqan\Pages\TiposAmb\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/tiposamb/editar/{id}', ['Tuqan\Pages\TiposAmb\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+
+$router->addRoute('POST', '/admin/tiposamb/nuevo', ['Tuqan\Pages\TiposAmb\Formulario', 'Procesar'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/tiposamb/editar/{id}', ['Tuqan\Pages\TiposAmb\Formulario', 'Procesar'], ['before' => 'auth_company']);
+
+$router->addRoute('GET', '/admin/tiposimp', ['Tuqan\Pages\TiposImp\Listado', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/tiposimp/nuevo', ['Tuqan\Pages\TiposImp\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/tiposimp/editar/{id}', ['Tuqan\Pages\TiposImp\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+
+$router->addRoute('POST', '/admin/tiposimp/nuevo', ['Tuqan\Pages\TiposImp\Formulario', 'Procesar'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/tiposimp/editar/{id}', ['Tuqan\Pages\TiposImp\Formulario', 'Procesar'], ['before' => 'auth_company']);
+
+$router->addRoute('GET', '/admin/tipo-cursos', ['Tuqan\Pages\TipoCursos\Listado', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/tipo-cursos/nuevo', ['Tuqan\Pages\TipoCursos\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/tipo-cursos/editar/{id}', ['Tuqan\Pages\TipoCursos\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+
+$router->addRoute('POST', '/admin/tipo-cursos/nuevo', ['Tuqan\Pages\TipoCursos\Formulario', 'Procesar'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/tipo-cursos/editar/{id}', ['Tuqan\Pages\TipoCursos\Formulario', 'Procesar'], ['before' => 'auth_company']);
+
+// Legacy for 8.8 modules (from full legacy menu accions)
+$router->addRoute('GET', '/administracion/tiposamb/listado/ver', ['Tuqan\Pages\TiposAmb\Listado', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/administracion/tiposimp/listado/ver', ['Tuqan\Pages\TiposImp\Listado', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/administracion/tipo_cursos/listado/ver', ['Tuqan\Pages\TipoCursos\Listado', 'ShowPage'], ['before' => 'auth_company']);
 
 // No generic catch-all route to avoid conflicts with auth filter and route ordering.
 // Unknown paths are handled gracefully in the exception block below.

--- a/reference/stage-8.8-finish-personalizacion-remaining-modules.md
+++ b/reference/stage-8.8-finish-personalizacion-remaining-modules.md
@@ -1,0 +1,139 @@
+# Stage 8.8 Plan — Finish Remaining Personalización Modules + Tipo Cursos
+
+**Status**: Planning phase
+**Branch target**: `feat/stage-8.8-finish-personalizacion-remaining-modules` (fresh from origin/master)
+**Driver**: Finish the last 2 items from the original 7 Personalizacion modules under Aplicacion (T. Amb. Aplicable / tiposamb and Tipos Imp. Amb. / tiposimp), add one more similar catalog module (Tipo Cursos) to keep the PR size similar to 8.6/8.7, deliver full modern Listado + Formulario + Procesar for all three, extend verification, update docs. Continue the menu-driven modernization pattern without introducing enhancements or scope creep.
+
+## Goals (Aligned with Previous User Directives and Plan)
+1. Complete the Personalizacion vertical slice by delivering the final 2 of the original 7 items with full modern pages (no more Placeholders for them).
+2. Add Tipo Cursos as the 3rd module in this leg (lightweight catalog like the others) so the change volume matches previous reviewable PRs.
+3. Maintain and extend the testing/verification approach (playbook, verify script updates, DB asserts, php -l, clean-room via init-db.sh).
+4. All work Docker-only, menu-driven (add/replace routes for modern + legacy accion paths, no menu_nuevo inserts needed since entries pre-exist from legacy import).
+5. Update all .agents/ docs, db-init docs, etc. before review.
+6. Keep PR size similar: ~3 full modules + patch + routes + verify expansion + docs.
+
+## Scope (Sized Similarly to 8.6/8.7 for Pace)
+- **3 full new modules** (to match the "3 full" volume from 8.7 and overall pace):
+  - Tipos Amb. Aplicable (tiposamb) — table + 3-5 demo rows, full Pages/TiposAmb/ + templates/, modern + legacy routes + POST.
+  - Tipos Imp. Amb. (tiposimp) — same.
+  - Tipo Cursos (tipocursos) — same. (Menu entry exists under Formacion area; follows the tipo* catalog pattern.)
+- Each: lightweight table (id serial pk, nombre text not null, activo boolean default true) + seeds in patch 0016.
+- Full pattern copy from TiposMejora/TiposAreas/TipoDocumento (Listado using Manejador + consulta, Formulario with ShowPage($id) + Procesar using consultaPreparada, module-specific flash keys in $_SESSION, redirects, validation).
+- Routes in index.php: clean /admin/tiposamb + /admin/tiposamb/nuevo + /admin/tiposamb/editar/{id} + POSTs; same for tiposimp; for tipocursos use /admin/tipo-cursos (hyphen for readability) + POSTs + legacy paths.
+- Legacy accion paths: /administracion/tiposamb/listado/ver etc. (and /nuevo variants to match style of prior) routed to the modern classes.
+- Update the "Remaining 2 Personalizacion children still basic/Placeholder" comment block.
+- **Verification & Testing**:
+  - New patch 0016 (tables + seeds + data_patches tracking; idempotent with ON CONFLICT).
+  - Extend scripts/verify-8.6.sh (rename comment / header to cover 8.8, add php -l for the 3 new, DB checks for new tables + row counts + 0016 in patches list).
+  - Add detailed "Stage 8.8 Verification Playbook" section in STAGE-CHECKLISTS.md (modeled exactly after 8.7/8.6: clean room with down -v + init-db.sh, php -l, psql asserts on tables/labels/patches after init, browser flows for create/edit + post-submit DB assert, flashes, no regressions).
+- **Docs & Housekeeping**:
+  - Full new section in .agents/STAGE-CHECKLISTS.md (todo items, validation commands, evidence skeleton, next steps).
+  - Update .agents/MIGRATION-PLAN.md (mark 8.7 complete with date/branch, introduce 8.8, update timeline).
+  - Update docker/db-init/README.md with 0016 note + full patch list.
+  - Any small cleanups (route comments, etc.).
+- **Out of scope for this PR** (to keep size + focus):
+  - Adding child menu_nuevo entries (nuevo/editar) for these — only sedes has them; the in-page "Nuevo"/"Editar" buttons + direct routes suffice and match what was done for the 8.7 modules.
+  - Leg. Aplicable or other remaining catalogs.
+  - Any matrix/menus/permisos/usuarios enhancements.
+  - New unit tests (follow current strategy: verify script + playbook + human browser gate).
+  - Table renames or legacy data migration for these (new dedicated tables like 8.7).
+
+**Expected size**: Similar to 8.6/8.7 (~3 full modules + 1 patch + routes for modern+legacy + verify script + full playbook section + 2-3 doc files). Reviewable, consistent pace.
+
+## Current Reality (Post 8.7 / #66 + #67)
+- 3 Personalizacion modules from 8.7 fully implemented with GET+POST (Tipos Acc. Mejora via tipoaccionesmejora, Tipos Area, Tipo Documento).
+- Clientes + Criterios full from 8.6.
+- The final 2 of the original 7 (T. Amb. Aplicable / administracion:tiposamb:listado:ver and Tipos Imp. Amb. / administracion:tiposimp:listado:ver) still route to Placeholder (see index.php:290-291).
+- Tipo Cursos menu entry exists (administracion:tipo_cursos:listado:ver under padre 91) but no modern page or table.
+- No tables for tiposamb, tiposimp, tipocursos (confirmed via psql).
+- Latest patch: 0015-personalizacion-remaining-modules.sql
+- verify-8.6.sh extended in place to cover 8.7 php -l + DB checks (still named 8.6 but handles 8.7).
+- All Aplicacion children under 82 now have modern pages *except* the 2 placeholders.
+- Menu labels/accions for the 2 are present (from full legacy import 0004 + 0010 restructure).
+- Docker stack running, DB clean-room reproducible via scripts/init-db.sh (applies 0001.. in order + data_patches guard).
+
+## Detailed Tasks / Patches
+1. New data patch:
+   - docker/db-init/data-patches/0016-personalizacion-last-two-plus-tipocursos.sql
+   - CREATE TABLE IF NOT EXISTS for tiposamb, tiposimp, tipocursos (id SERIAL PRIMARY KEY, nombre TEXT NOT NULL, activo BOOLEAN NOT NULL DEFAULT true)
+   - INSERT 3-5 demo rows each (ON CONFLICT DO NOTHING)
+   - INSERT INTO data_patches (filename, applied_at) ... ON CONFLICT DO NOTHING
+   - Comments on tables noting Stage 8.8 / Personalizacion catalog.
+   - No menu inserts (entries pre-exist).
+
+2. Code for 3 modules (copy/adapt from TiposMejora exactly):
+   - Pages/TiposAmb/{Listado.php, Formulario.php}
+     - Namespace Tuqan\Pages\TiposAmb
+     - Listado: query "SELECT id, nombre, activo FROM tiposamb ORDER BY id", map to array, pass as 'tiposamb', use flash keys 'tiposamb_flash_success' / 'tiposamb_form_error'
+     - Formulario: ShowPage($id=null) with edit load via consultaPreparada, Procesar with trim+required validation on nombre, INSERT/UPDATE via preparada, set flash, redirect to /admin/tiposamb
+   - Same for TiposImp (table tiposimp, keys 'tiposimp_*', routes /admin/tiposimp , pageTitle "Tipos Imp. Amb.")
+   - Same for TipoCursos (table tipocursos, keys 'tipocursos_*', modern route /admin/tipo-cursos for cleanliness + legacy, pageTitle "Tipo Cursos")
+
+3. Templates (copy/adapt from templates/tiposmejora/ ):
+   - templates/tiposamb/listado.twig + formulario.twig
+   - templates/tiposimp/...
+   - templates/tipocursos/...
+   - Use extends "layouts/app.twig", page header with Nuevo/Volver, table or form, flash divs inside content (matching the 8.7 modules), small "Stage 8.8" info note at bottom.
+   - Adapt labels, action URLs, variable names, titles to the module.
+
+4. Routes in index.php:
+   - Add the full set for /admin/tiposamb* (GET list/nuevo/editar, POST nuevo/editar) + legacy /administracion/tiposamb/listado/ver (and /nuevo style if present in other)
+   - Same for /admin/tiposimp*
+   - For TipoCursos: /admin/tipo-cursos + /admin/tipo-cursos/nuevo + /admin/tipo-cursos/editar/{id} + POSTs + legacy /administracion/tipo_cursos/listado/ver
+   - Remove or comment the 2 Placeholder lines for tiposamb/tiposimp.
+   - Update the comment: // Stage 8.8: last 2 Personalizacion + Tipo Cursos now full
+   - Ensure legacy for the new ones are present (like 8.7 did for some).
+
+5. Verification:
+   - Extend scripts/verify-8.6.sh : update header/echo to "Stage 8.6 / 8.7 / 8.8", add the 3 new *Listado.php *Formulario.php to the php -l line, add to the psql union counts + tables list + patch filter, add specific SELECT for the new tables.
+   - New "Stage 8.8 Verification Playbook" section in .agents/STAGE-CHECKLISTS.md (copy structure from 8.7: goal, selected scope, key changes, evidence commands, DB gates, browser flows for create/edit + post DB assert on new tables, next steps).
+   - In playbook: note that init-db.sh + psql will apply 0016.
+
+6. Docs:
+   - New Stage 8.8 section in STAGE-CHECKLISTS.md modeled on 8.7.
+   - Update MIGRATION-PLAN.md : mark Stage 8.7 completed (date, branch, PR), add 8.8 bullet in timeline + "Stage 8.8 (in progress / completed)" note.
+   - docker/db-init/README.md : add 0016 to the patch list + short description.
+   - (Optional) root Readme.md or others if they list modules.
+
+## Risks & Mitigations
+- Table name choice: Using short tiposamb / tiposimp / tipocursos (no legacy conflict found; consistent with how 8.7 chose tipoaccionesmejora etc. for display names). Documented in patch.
+- Route legacy paths: Match exactly the accion in menu (e.g. administracion:tiposamb:listado:ver -> /administracion/tiposamb/listado/ver). Added both clean /admin/ and legacy.
+- Flash/session keys: Per-module to avoid collision (as in all prior catalog modules); passed through to layout + rendered in content templates.
+- Size: Strictly 3 modules + 1 patch + routes + 1 script update + 3 doc updates. No more.
+- No child menu entries: Matches what 8.7 delivered for its 3 (sedes is the exception from earlier); in-page buttons provide the flows.
+- Verification: Playbook will be long but reusable; script keeps non-interactive part practical.
+
+## Execution Order (Strict, like 8.5/8.7)
+1. Write this plan + supporting reference (this file) — on the new branch as first commit.
+2. Implement data patch 0016 + apply/verify with docker compose exec app ./scripts/init-db.sh + psql checks.
+3. Implement the 3 full modules (code under Pages/ + templates/ + routes in index.php).
+4. Extend verify-8.6.sh + add full verification playbook section to checklists.
+5. Update all other docs (MIGRATION-PLAN, db-init/README, etc.).
+6. Full Docker verification (php -l via script or direct, init + psql asserts for new tables/patch, exercise via browser or LegacyAction paths, confirm no regressions on prior modules).
+7. Commit in logical chunks, push, open PR. (Follow AGENTS.md + todo_write; only circle back if blocked.)
+
+## Success Criteria
+- After patch + init-db.sh: the 3 new tables exist, have >=3 rows each, data_patches includes '0016-...sql', no errors.
+- The 2 previous Placeholder entries now resolve to modern Listado (clicking in sidebar under Personalizacion works; /admin/tiposamb and /admin/tiposimp and legacy paths render the list with "Nuevo" button).
+- Tipo Cursos also has modern page at its legacy-resolved path + clean /admin/tipo-cursos.
+- Create + edit for all 3 work end-to-end: submit form → success flash (in list) → row appears/updated in table → psql confirms the nombre/activo.
+- Flashes appear (both content and layout if applicable), validation rejects empty nombre, redirects correct.
+- verify-8.6.sh (updated) passes php -l + basic DB asserts for the 3 + patch.
+- Full playbook commands (clean room) pass; human browser pass would cover the flows (per "continue a couple of legs" + deliberate non-interactive until gaps found).
+- No regressions (existing Perfiles/Sedes/Clientes/.../Tipos* still work, menu sidebar still shows all Aplicacion items).
+- All changes in one clean, reviewable PR with proper evidence appended to .agents/ docs.
+- Docker-only, consistent with previous stages.
+
+## Related
+- Continues directly from 8.7 (finishes the exact "Remaining 2 Personalizacion" called out in 8.7 checklists "Next in this or follow-up legs").
+- Completes the Aplicacion submenu modernization focus from the original user request (profiles, empresas/sedes, menus, idiomas, permisos, and now all 7 Personalizacion items + bonus Tipo Cursos for size).
+- Prepares ground for deeper sections (other top-level like Documentacion, Calidad, or full Usuarios enhancements / POSTs if gaps found after legs).
+- Reinforces the testing strategy (playbook + script will be updated).
+
+---
+
+*Part of the ongoing menu-driven modernization (Stage 8.x). June 2026.*
+
+**Execution will be autonomous per AGENTS.md once branch created. Only circle back on blockers.**
+
+**Plan written on the feature branch (first commit).**

--- a/scripts/verify-8.6.sh
+++ b/scripts/verify-8.6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # verify-8.6.sh
-# Non-interactive checks for the major 8.6 functional changes (POST modules, Sedes rename, new Personalizacion tables, etc.).
+# Non-interactive checks for the major 8.6/8.7/8.8 functional changes (POST modules, Sedes rename, new Personalizacion tables, last 2 + Tipo Cursos, etc.).
 # Run inside the app container after init-db.sh:
 #   docker compose exec app ./scripts/verify-8.6.sh
 #
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-echo "=== Stage 8.6 / 8.7 Verification (non-interactive) ==="
+echo "=== Stage 8.6 / 8.7 / 8.8 Verification (non-interactive) ==="
 echo ""
 
 echo "1. Syntax check on key files..."
@@ -22,16 +22,19 @@ php -l Pages/Sedes/Listado.php Pages/Sedes/Formulario.php \
     Pages/TiposAreas/Listado.php Pages/TiposAreas/Formulario.php \
     Pages/TipoDocumento/Listado.php Pages/TipoDocumento/Formulario.php \
     Pages/Permisos/Formulario.php Pages/Menus/Listado.php \
+    Pages/TiposAmb/Listado.php Pages/TiposAmb/Formulario.php \
+    Pages/TiposImp/Listado.php Pages/TiposImp/Formulario.php \
+    Pages/TipoCursos/Listado.php Pages/TipoCursos/Formulario.php \
     index.php > /dev/null
-echo "   PASS: No syntax errors in the main 8.6/8.7 files."
+echo "   PASS: No syntax errors in the main 8.6/8.7/8.8 files."
 
 echo ""
 echo "2. DB state checks (tables from 0012/0013/0014/0015 + menu updates)..."
 export PGPASSWORD="${DB_PASS:-secret}"
 psql -h "${DB_HOST:-db}" -U qnova -d qnova -v ON_ERROR_STOP=1 -c "
--- Tables (8.6 + 8.7)
+-- Tables (8.6 + 8.7 + 8.8)
 SELECT tablename FROM pg_tables 
-WHERE schemaname='public' AND tablename IN ('sedes','clientes','criterios','tiposmejora','empresas','tipoaccionesmejora','tiposareas','tipodocumento')
+WHERE schemaname='public' AND tablename IN ('sedes','clientes','criterios','tiposmejora','empresas','tipoaccionesmejora','tiposareas','tipodocumento','tiposamb','tiposimp','tipocursos')
 ORDER BY tablename;
 
 -- Sedes rename evidence
@@ -43,7 +46,7 @@ SELECT valor FROM menu_idiomas_nuevo
 WHERE menu = (SELECT id FROM menu_nuevo WHERE accion LIKE '%sedes%' ORDER BY id LIMIT 1)
   AND idioma_id = 1;
 
--- New Personalizacion modules (8.6 + 8.7)
+-- New Personalizacion modules (8.6 + 8.7 + 8.8)
 SELECT 'clientes' AS t, COUNT(*) FROM clientes
 UNION ALL
 SELECT 'criterios', COUNT(*) FROM criterios
@@ -54,9 +57,15 @@ SELECT 'tipoaccionesmejora', COUNT(*) FROM tipoaccionesmejora
 UNION ALL
 SELECT 'tiposareas', COUNT(*) FROM tiposareas
 UNION ALL
-SELECT 'tipodocumento', COUNT(*) FROM tipodocumento;
+SELECT 'tipodocumento', COUNT(*) FROM tipodocumento
+UNION ALL
+SELECT 'tiposamb', COUNT(*) FROM tiposamb
+UNION ALL
+SELECT 'tiposimp', COUNT(*) FROM tiposimp
+UNION ALL
+SELECT 'tipocursos', COUNT(*) FROM tipocursos;
 
--- Patch tracking (up to 0015)
+-- Patch tracking (up to 0016)
 SELECT filename FROM data_patches 
 WHERE filename LIKE '001%' 
 ORDER BY filename;
@@ -66,5 +75,5 @@ echo ""
 echo "3. (Class load smoke skipped in this script because it is fragile from different CWDs; the php -l above already gives us syntax confidence. Full route exercising requires a real session and is covered in the browser + DB-assert part of the playbook.)"
 
 echo ""
-echo "=== 8.6/8.7 non-interactive verification finished ==="
+echo "=== 8.6/8.7/8.8 non-interactive verification finished ==="
 echo "For the real confidence on the POST behavior, flashes, matrix, editing, etc., follow the full playbook in .agents/STAGE-CHECKLISTS.md (the browser + DB-assert-after-submit part)."

--- a/templates/tipocursos/formulario.twig
+++ b/templates/tipocursos/formulario.twig
@@ -1,0 +1,45 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}{{ pageTitle }} - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <h2 style="margin: 0; font-size: 20px;">{{ pageTitle }}</h2>
+        <div>
+            <a href="/admin/tipo-cursos" class="btn btn-default btn-sm">Volver al listado</a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px; max-width: 600px;">
+    <form method="POST" action="{{ isEdit ? '/admin/tipo-cursos/editar/' ~ tipocursos.id : '/admin/tipo-cursos/nuevo' }}">
+        <div class="form-group">
+            <label for="nombre">Nombre del Tipo de Curso</label>
+            <input type="text" class="form-control" id="nombre" name="nombre"
+                   value="{{ tipocursos.nombre ?? '' }}" required>
+        </div>
+
+        <div class="form-group">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="activo" value="1"
+                           {% if not isEdit or tipocursos.activo %}checked{% endif %}>
+                    Activo
+                </label>
+            </div>
+        </div>
+
+        <div class="form-group" style="margin-top: 20px;">
+            <button type="submit" class="btn btn-primary">
+                {{ isEdit ? 'Guardar cambios' : 'Crear Tipo' }}
+            </button>
+            <a href="/admin/tipo-cursos" class="btn btn-default" style="margin-left: 8px;">Cancelar</a>
+        </div>
+
+        <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
+            Módulo completo (Stage 8.8).
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/templates/tipocursos/listado.twig
+++ b/templates/tipocursos/listado.twig
@@ -1,0 +1,52 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}Tipo Cursos - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <h2 style="margin: 0; font-size: 20px;">Tipo Cursos</h2>
+        <div>
+            <a href="/admin/tipo-cursos/nuevo" class="btn btn-primary btn-sm">
+                <span class="glyphicon glyphicon-plus"></span> Nuevo Tipo
+            </a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px;">
+    {% if flashSuccess %}
+        <div class="alert alert-success">{{ flashSuccess }}</div>
+    {% endif %}
+    {% if flashError %}
+        <div class="alert alert-danger">{{ flashError }}</div>
+    {% endif %}
+
+    {% if tipocursos is empty %}
+        <div class="alert alert-info">No hay tipos de cursos registrados.</div>
+    {% else %}
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr><th>ID</th><th>Nombre</th><th>Estado</th><th style="width:140px;text-align:right;">Acciones</th></tr>
+                </thead>
+                <tbody>
+                    {% for t in tipocursos %}
+                    <tr>
+                        <td>{{ t.id }}</td>
+                        <td><strong>{{ t.nombre }}</strong></td>
+                        <td>{% if t.activo %}<span class="label label-success">Activo</span>{% else %}<span class="label label-default">Inactivo</span>{% endif %}</td>
+                        <td style="text-align:right;">
+                            <a href="/admin/tipo-cursos/editar/{{ t.id }}" class="btn btn-xs btn-default">Editar</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+    <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
+        Tipo Cursos — módulo completo (Stage 8.8).
+    </div>
+</div>
+{% endblock %}

--- a/templates/tiposamb/formulario.twig
+++ b/templates/tiposamb/formulario.twig
@@ -1,0 +1,45 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}{{ pageTitle }} - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <h2 style="margin: 0; font-size: 20px;">{{ pageTitle }}</h2>
+        <div>
+            <a href="/admin/tiposamb" class="btn btn-default btn-sm">Volver al listado</a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px; max-width: 600px;">
+    <form method="POST" action="{{ isEdit ? '/admin/tiposamb/editar/' ~ tiposamb.id : '/admin/tiposamb/nuevo' }}">
+        <div class="form-group">
+            <label for="nombre">Nombre del Tipo Amb. Aplicable</label>
+            <input type="text" class="form-control" id="nombre" name="nombre"
+                   value="{{ tiposamb.nombre ?? '' }}" required>
+        </div>
+
+        <div class="form-group">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="activo" value="1"
+                           {% if not isEdit or tiposamb.activo %}checked{% endif %}>
+                    Activo
+                </label>
+            </div>
+        </div>
+
+        <div class="form-group" style="margin-top: 20px;">
+            <button type="submit" class="btn btn-primary">
+                {{ isEdit ? 'Guardar cambios' : 'Crear Tipo' }}
+            </button>
+            <a href="/admin/tiposamb" class="btn btn-default" style="margin-left: 8px;">Cancelar</a>
+        </div>
+
+        <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
+            Módulo completo bajo Personalización (Stage 8.8).
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/templates/tiposamb/listado.twig
+++ b/templates/tiposamb/listado.twig
@@ -1,0 +1,52 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}Tipos Amb. Aplicable - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <h2 style="margin: 0; font-size: 20px;">Tipos Amb. Aplicable</h2>
+        <div>
+            <a href="/admin/tiposamb/nuevo" class="btn btn-primary btn-sm">
+                <span class="glyphicon glyphicon-plus"></span> Nuevo Tipo
+            </a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px;">
+    {% if flashSuccess %}
+        <div class="alert alert-success">{{ flashSuccess }}</div>
+    {% endif %}
+    {% if flashError %}
+        <div class="alert alert-danger">{{ flashError }}</div>
+    {% endif %}
+
+    {% if tiposamb is empty %}
+        <div class="alert alert-info">No hay tipos de ambiente aplicable registrados.</div>
+    {% else %}
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr><th>ID</th><th>Nombre</th><th>Estado</th><th style="width:140px;text-align:right;">Acciones</th></tr>
+                </thead>
+                <tbody>
+                    {% for t in tiposamb %}
+                    <tr>
+                        <td>{{ t.id }}</td>
+                        <td><strong>{{ t.nombre }}</strong></td>
+                        <td>{% if t.activo %}<span class="label label-success">Activo</span>{% else %}<span class="label label-default">Inactivo</span>{% endif %}</td>
+                        <td style="text-align:right;">
+                            <a href="/admin/tiposamb/editar/{{ t.id }}" class="btn btn-xs btn-default">Editar</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+    <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
+        Tipos Amb. Aplicable — módulo completo bajo Personalización (Stage 8.8).
+    </div>
+</div>
+{% endblock %}

--- a/templates/tiposimp/formulario.twig
+++ b/templates/tiposimp/formulario.twig
@@ -1,0 +1,45 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}{{ pageTitle }} - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <h2 style="margin: 0; font-size: 20px;">{{ pageTitle }}</h2>
+        <div>
+            <a href="/admin/tiposimp" class="btn btn-default btn-sm">Volver al listado</a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px; max-width: 600px;">
+    <form method="POST" action="{{ isEdit ? '/admin/tiposimp/editar/' ~ tiposimp.id : '/admin/tiposimp/nuevo' }}">
+        <div class="form-group">
+            <label for="nombre">Nombre del Tipo Imp. Amb.</label>
+            <input type="text" class="form-control" id="nombre" name="nombre"
+                   value="{{ tiposimp.nombre ?? '' }}" required>
+        </div>
+
+        <div class="form-group">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="activo" value="1"
+                           {% if not isEdit or tiposimp.activo %}checked{% endif %}>
+                    Activo
+                </label>
+            </div>
+        </div>
+
+        <div class="form-group" style="margin-top: 20px;">
+            <button type="submit" class="btn btn-primary">
+                {{ isEdit ? 'Guardar cambios' : 'Crear Tipo' }}
+            </button>
+            <a href="/admin/tiposimp" class="btn btn-default" style="margin-left: 8px;">Cancelar</a>
+        </div>
+
+        <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
+            Módulo completo bajo Personalización (Stage 8.8).
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/templates/tiposimp/listado.twig
+++ b/templates/tiposimp/listado.twig
@@ -1,0 +1,52 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}Tipos Imp. Amb. - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <h2 style="margin: 0; font-size: 20px;">Tipos Imp. Amb.</h2>
+        <div>
+            <a href="/admin/tiposimp/nuevo" class="btn btn-primary btn-sm">
+                <span class="glyphicon glyphicon-plus"></span> Nuevo Tipo
+            </a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px;">
+    {% if flashSuccess %}
+        <div class="alert alert-success">{{ flashSuccess }}</div>
+    {% endif %}
+    {% if flashError %}
+        <div class="alert alert-danger">{{ flashError }}</div>
+    {% endif %}
+
+    {% if tiposimp is empty %}
+        <div class="alert alert-info">No hay tipos de impacto ambiental registrados.</div>
+    {% else %}
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr><th>ID</th><th>Nombre</th><th>Estado</th><th style="width:140px;text-align:right;">Acciones</th></tr>
+                </thead>
+                <tbody>
+                    {% for t in tiposimp %}
+                    <tr>
+                        <td>{{ t.id }}</td>
+                        <td><strong>{{ t.nombre }}</strong></td>
+                        <td>{% if t.activo %}<span class="label label-success">Activo</span>{% else %}<span class="label label-default">Inactivo</span>{% endif %}</td>
+                        <td style="text-align:right;">
+                            <a href="/admin/tiposimp/editar/{{ t.id }}" class="btn btn-xs btn-default">Editar</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+    <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
+        Tipos Imp. Amb. — módulo completo bajo Personalización (Stage 8.8).
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
New day, new leg (similar size to 8.6/8.7).

**Scope (per plan in reference/stage-8.8-finish-personalizacion-remaining-modules.md):**
- Finish the last 2 of the original 7 Personalizacion items (T. Amb. Aplicable / tiposamb and Tipos Imp. Amb. / tiposimp — the only remaining Placeholder entries under Aplicacion).
- Add Tipo Cursos as 3rd module for volume parity (lightweight catalog like the 8.7 ones).
- Patch 0016: 3 new tables (tiposamb, tiposimp, tipocursos) + demo seeds + data_patches record (idempotent).
- Full modern pages: Pages/TiposAmb/, TiposImp/, TipoCursos/ (Listado + Formulario with Procesar, validation, flashes, redirects) + matching templates.
- Routes: modern /admin/tiposamb + /nuevo/editar + POSTs (and same for others; /tipo-cursos for the third); legacy /administracion/... paths so menu clicks work. Removed last Placeholder routes.
- Extended verify-8.6.sh (php -l + DB checks now cover 8.8).
- Full new Stage 8.8 Verification Playbook in .agents/STAGE-CHECKLISTS.md + updated 8.7 as completed.
- MIGRATION-PLAN.md updated (8.7 complete, 8.8 added).
- docker/db-init/README.md patch list updated.

**Verification (non-interactive, all passed):**
- php -l clean on all new Pages + index.php.
- docker compose exec app ./scripts/verify-8.6.sh → PASS (new tables, row counts, 0016 in patches, syntax).
- psql confirms menu accions/labels for the 3 entries + tables/seeds.
- 4 commits on branch (plan as first commit, per pattern).
- Pushed: feat/stage-8.8-finish-personalizacion-remaining-modules

**Full reproducible playbook + browser flows + post-submit DB asserts** in .agents/STAGE-CHECKLISTS.md (Stage 8.8 section) and the reference plan. Docker-only, menu-driven, follows all prior conventions (no enhancements, reviewable size, docs-first).

See the plan file for execution order, success criteria, and risks. Ready for review/merge.

(Continuing autonomous legs per "continue a couple of legs before interactive" + "new day, new leg" directive.)