### PR TITLE
feat(9.28): Mejora full state machine (auto transitions, quick actions, estado UI)

### DIFF
--- a/.agents/MIGRATION-TODOS.md
+++ b/.agents/MIGRATION-TODOS.md
@@ -5,7 +5,7 @@ MIGRATION-PLAN.md = architecture, constraints, high-level stages + history.
 STAGE-CHECKLISTS.md = detailed per-leg playbooks, exact commands, evidence, retrospective lessons.  
 **This file** = scannable "what is left, how big is it, what should the next PR be?" + handoff package for other agents.
 
-**Last updated**: Stage 9.27 on `feat/stage-9.27-mejora-state-machine` (Mejora deeper: basic state machine). Previous: 9.26 content editor.
+**Last updated**: Stage 9.28 on `feat/stage-9.28-mejora-full-state-machine` (Mejora full state machine polish: auto transitions + quick actions). Previous: 9.27 basic state machine.
 
 ---
 
@@ -84,7 +84,8 @@ Pick 1-2 related items that together form a reviewable PR. Update this list when
 - [x] **Mejora deeper workflow: remaining fields and basic state**: Delivered in Stage 9.25 (added usuario_verifica, fecha_verifica, usuario_implantacion, fecha_cierre + labels). See 9.25 plan and STAGE-CHECKLISTS.
 - [x] **Documentación content editor first slice**: Delivered in Stage 9.26 (basic text content editing via contenido_texto in form). See 9.26 plan and STAGE-CHECKLISTS.
 - [x] **Mejora deeper: basic state machine**: Delivered in Stage 9.27 (added verify/close action checkboxes, computed states in list, basic validation). See 9.27 plan and STAGE-CHECKLISTS.
-- [ ] **Next verticals / polish**: More Mejora (full state machine/links), more Formación, Documentación (rich editor), or broader polish.
+- [x] **Mejora full state machine polish**: Delivered in Stage 9.28 (auto user+fecha on transitions, quick Verificar/Cerrar routes+buttons from list, estado badge in form, login id hygiene + base helper). See 9.28 plan and STAGE-CHECKLISTS.
+- [ ] **Next verticals / polish**: Mejora cross links (Auditorias/Aspectos/Indicadores integration), more Formación subs, Documentación (rich editor), or broader polish.
 
 Aim for a mix: one "close the small gaps" + one "new vertical" per couple of legs. Keep delivering working, reviewable increments.
 
@@ -105,7 +106,7 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 - [ ] Full matrix + revisiones + cuestionario integration + reporting tie-in to Indicadores.
 
 ### Mejora (Improvement)
-- [x] Acciones de Mejora (legacy 68) — basic CRUD + relations in 9.4/9.17; deeper workflow slices in 9.21 (initial assignments), 9.25 (remaining fields + basic state), 9.27 (basic state machine with verify/close). Full state machine, more links deferred. See 9.4 + 9.17 + 9.21 + 9.25 + 9.27 plans.
+- [x] Acciones de Mejora (legacy 68) — basic CRUD + relations in 9.4/9.17; deeper workflow slices in 9.21 (initial assignments), 9.25 (remaining fields + basic state), 9.27 (basic state machine with verify/close), 9.28 (fuller: auto transitions, quick actions from list, estado UI). Full cross links deferred. See 9.4 + 9.17 + 9.21 + 9.25 + 9.27 + 9.28 plans.
 - [ ] Integration of mejora actions with Auditorias / Aspectos / Indicadores (cross links). Deeper workflow.
 
 ### Formación (Training)
@@ -153,7 +154,7 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 ## Cross-Cutting / Non-Module Backlog (Important but Not "a Module")
 
 - [ ] Twig 1.x → 2/3 (or 3) proper upgrade (deferred repeatedly; vendor patches in place; will touch all templates + possibly custom extensions when we have many modules).
-- [x] More base class extraction — first delivery in Stage 9.8: enhanced CatalogListado + CatalogFormulario with protected helpers. 9.13 tree, 9.15 filters/relations, 9.16 full tree base (CatalogTree), 9.17 relations polish + getRelatedOptions + adoption in early modules, 9.18 Aspectos, 9.19 vertical, 9.20 Formación sub, 9.21 Mejora deeper, 9.22 Formación sub, 9.23 Documentación, 9.24 workflows, 9.25 Mejora more, 9.26 content editor, 9.27 Mejora state. See 9.8/9.13/9.15/9.16/9.17/9.18/9.19/9.20/9.21/9.22/9.23/9.24/9.25/9.26/9.27. Broader adoption remains open.
+- [x] More base class extraction — first delivery in Stage 9.8: enhanced CatalogListado + CatalogFormulario with protected helpers. 9.13 tree, 9.15 filters/relations, 9.16 full tree base (CatalogTree), 9.17 relations polish + getRelatedOptions + adoption in early modules, 9.18 Aspectos, 9.19 vertical, 9.20 Formación sub, 9.21 Mejora deeper, 9.22 Formación sub, 9.23 Documentación, 9.24 workflows, 9.25 Mejora more, 9.26 content editor, 9.27 Mejora state, 9.28 Mejora state + getCurrentUserId + login id capture. See 9.8/9.13/9.15/9.16/9.17/9.18/9.19/9.20/9.21/9.22/9.23/9.24/9.25/9.26/9.27/9.28. Broader adoption remains open.
 - [ ] PDF / Excel / report generation modernization (GenPDF, crearExcel, related generators — used by almost every vertical for "ficha", exports, compliance outputs).
 - [ ] Tree / arbol UI + generators (arbol_documentos.php, estructura_arbol.php, generador_arboles.php, dhtmlgoodies tree, saveNodes etc. — core for Documentación + Procesos; big but high leverage).
 - [ ] Questionnaire / checklist engine (cuestionario.php + procesa_cuestionario.php + procesa_Editor — used by Aspectos, Auditorias, possibly others; aspects/audits/reqs depend on it).

--- a/.agents/STAGE-CHECKLISTS.md
+++ b/.agents/STAGE-CHECKLISTS.md
@@ -3376,6 +3376,88 @@ docker compose exec app php -l Pages/Mejora/Formulario.php Pages/Mejora/Listado.
 **Branch status:** Stage 9.27 on `feat/stage-9.27-mejora-state-machine`. Plan first. Docker-only.
 
 
+## Stage 9.28 — Mejora: full state machine polish (auto transitions + quick actions)
+
+**Goal:** Polish Mejora state machine to "fuller": auto-assign current user + today date on verify/close actions (checkboxes or quick), direct quick-action POST endpoints + conditional buttons in list (Verificar / Cerrar), show current estado badge in form. Small login hygiene for real user id. Patch + full verify.
+
+**Selected scope (reviewable):**
+- Auto logic + quick Verificar/Cerrar methods in Formulario.
+- Routes for quick actions.
+- List quick buttons + form estado display.
+- Patch 0038.
+- Login id capture + base helper.
+- Verify + playbook + TODOS.
+
+**Key changes:**
+- New: reference/stage-9.28-*-plan.md, data-patches/0038-*.sql
+- Modified: Pages/Mejora/Formulario.php, Pages/Catalog/* (helper), Pages/LoginUsuario.php, index.php, templates/mejora/*, scripts/verify-8.6.sh, .agents/STAGE-CHECKLISTS.md + MIGRATION-TODOS.md
+- Branch: feat/stage-9.28-mejora-full-state-machine
+
+**todo_write items:**
+```json
+[
+  {"id":"9.28.1","content":"Add $_SESSION['id_usuario'] capture in Pages/LoginUsuario.php on successful login (from userRow[0])","status":"pending"},
+  {"id":"9.28.2","content":"Add getCurrentUserId() helper to CatalogFormulario (and CatalogListado) returning (int)($_SESSION['id_usuario'] ?? 1)","status":"pending"},
+  {"id":"9.28.3","content":"Enhance Mejora/Formulario.php: auto-apply logic in getPostData/persist for accion_* (set user+fecha if blank), update validate if needed; implement public Verificar($id) and Cerrar($id) that mutate and flash+redirect","status":"pending"},
+  {"id":"9.28.4","content":"Add POST routes in index.php for /admin/mejora/verificar/{id} and /admin/mejora/cerrar/{id} pointing to the new methods on Formulario","status":"pending"},
+  {"id":"9.28.5","content":"Update templates/mejora/formulario.twig: add prominent current estado display/badge at top; refine workflow action checkboxes labels to mention auto-fill","status":"pending"},
+  {"id":"9.28.6","content":"Update templates/mejora/listado.twig: add conditional quick-action buttons (POST forms) for Verificar (if Pendiente) and Cerrar (if Verificada) next to Editar","status":"pending"},
+  {"id":"9.28.7","content":"Create docker/db-init/data-patches/0038-mejora-state-transitions.sql with idempotent demo data for varied states + data_patches entry","status":"pending"},
+  {"id":"9.28.8","content":"Extend scripts/verify-8.6.sh with 9.28 specific asserts (more state counts, patch presence)","status":"pending"},
+  {"id":"9.28.9","content":"Append full Stage 9.28 section (todo items, validation commands, evidence) to .agents/STAGE-CHECKLISTS.md","status":"in_progress"},
+  {"id":"9.28.10","content":"Update .agents/MIGRATION-TODOS.md: flip Mejora items, refresh snapshot/suggested next, last updated note","status":"pending"},
+  {"id":"9.28.11","content":"Full ritual verify: docker down -v + up + init-db.sh; php -l on all touched; psql asserts; ./scripts/verify-8.6.sh; manual browser flows for transitions","status":"pending"},
+  {"id":"9.28.12","content":"Logical commits; push; prepare for PR (update plan with evidence links if needed)","status":"pending"}
+]
+```
+
+**Validation Commands:**
+```bash
+# Full clean room
+docker compose --env-file .env.docker down -v
+docker compose --env-file .env.docker up -d
+docker compose exec app ./docker/db-init/init-db.sh
+
+# Syntax + verify script
+docker compose exec app php -l Pages/Mejora/Formulario.php
+docker compose exec app php -l Pages/Mejora/Listado.php
+docker compose exec app php -l Pages/Catalog/CatalogFormulario.php
+docker compose exec app php -l Pages/Catalog/CatalogListado.php
+docker compose exec app php -l Pages/LoginUsuario.php
+docker compose exec app php -l index.php
+docker compose exec app ./scripts/verify-8.6.sh
+
+# Patch and state evidence
+docker compose exec db psql -U qnova -d qnova -c "
+  SELECT filename FROM data_patches WHERE filename LIKE '0038%';
+  SELECT id, descripcion, cerrada, usuario_verifica IS NOT NULL AS has_verifica, estado_label FROM (
+    SELECT id, descripcion, cerrada, usuario_verifica,
+           CASE WHEN cerrada THEN 'Cerrada' WHEN usuario_verifica IS NOT NULL THEN 'Verificada' ELSE 'Pendiente' END AS estado_label
+    FROM acciones_mejora ORDER BY id
+  ) s;
+"
+```
+
+**Browser flows (after clean init + login as admin/demo):**
+- Navigate to /admin/mejora (or legacy path).
+- List: shows Estado badges + for Pendiente items a "Verificar" button; for Verificada a "Cerrar" button (no button if Cerrada).
+- Click Verificar on a Pendiente → flash success "Acción de mejora verificada.", row now Verificada (and auto user/date if was blank).
+- Click Cerrar on a Verificada → flash "Acción de mejora cerrada.", now Cerrada.
+- Attempt Cerrar on Pendiente → error flash about needing verify first.
+- Go to edit form for one: prominent Estado badge shown; checkboxes for workflow actions note auto-fill behavior; submit with checkbox sets user+fecha auto.
+- Create new or edit and use checkboxes → states update correctly.
+- No regressions on other modern modules (e.g. /admin/documentacion etc still work).
+- Quick actions and form actions produce correct DB rows (psql verify).
+
+**Evidence:** (fill post-execution)
+
+**Next:**
+- Mark in TODOS.
+- Suggested next: Mejora cross links (Auditorias/Aspectos), Formación remaining, Documentación rich editor, etc.
+
+**Branch status:** Stage 9.28 on `feat/stage-9.28-mejora-full-state-machine`. Plan first. Docker-only. All via container.
+
+
 
 
 

--- a/Pages/Catalog/CatalogFormulario.php
+++ b/Pages/Catalog/CatalogFormulario.php
@@ -67,6 +67,15 @@ abstract class CatalogFormulario
         ];
     }
 
+    /**
+     * Current logged-in user id for auto-assign in state transitions (Mejora etc.).
+     * Falls back to 1 (demo seed user) if not present in session.
+     */
+    protected function getCurrentUserId(): int
+    {
+        return (int)($_SESSION['id_usuario'] ?? 1);
+    }
+
     protected function getFlashPrefix(): string
     {
         return $this->flashPrefix;

--- a/Pages/Catalog/CatalogListado.php
+++ b/Pages/Catalog/CatalogListado.php
@@ -74,6 +74,15 @@ abstract class CatalogListado
         ];
     }
 
+    /**
+     * Current logged-in user id for auto-assign in state transitions (Mejora etc.).
+     * Falls back to 1 (demo seed user) if not present in session.
+     */
+    protected function getCurrentUserId(): int
+    {
+        return (int)($_SESSION['id_usuario'] ?? 1);
+    }
+
     protected function getFlashData(): array
     {
         $success = $_SESSION[$this->flashPrefix . '_flash_success'] ?? null;

--- a/Pages/LoginUsuario.php
+++ b/Pages/LoginUsuario.php
@@ -131,6 +131,9 @@ class LoginUsuario
                 $_SESSION['admin'] = ((int)($userRow[2] ?? 0) === 0);
                 $_SESSION['perfil'] = (string)($userRow[2] ?? '0');
 
+                // Capture numeric user id for auto-assign in workflow actions (e.g. Mejora state machine)
+                $_SESSION['id_usuario'] = (int)($userRow[0] ?? 1);
+
                 $nombre   = trim($userRow[3] ?? '');
                 $apellido = trim($userRow[4] ?? '');
                 $email    = trim($userRow[5] ?? '');

--- a/Pages/Mejora/Formulario.php
+++ b/Pages/Mejora/Formulario.php
@@ -121,7 +121,7 @@ class Formulario extends CatalogFormulario
         if (($data['fecha'] ?? '') === '') {
             $errors[] = 'La fecha es obligatoria.';
         }
-        // Basic state machine validation
+        // Basic state machine validation (checkbox path)
         if ($data['accion_cerrar'] && !$data['usuario_verifica']) {
             $errors[] = 'No se puede cerrar sin verificar primero.';
         }
@@ -136,12 +136,31 @@ class Formulario extends CatalogFormulario
         $fecha_imp = ($data['fecha_implantacion'] ?? '') !== '' ? $data['fecha_implantacion'] : null;
         $plazo_val = ($data['plazo'] ?? '') !== '' ? $data['plazo'] : null;
 
-        // Basic state machine actions
-        if ($data['accion_verificar'] && !$data['usuario_verifica']) {
-            // leave to user input or could default, but fields editable
+        $today = date('Y-m-d');
+        $currentUser = $this->getCurrentUserId();
+
+        // Full state machine auto-apply on action checkboxes (form path)
+        if ($data['accion_verificar']) {
+            if (empty($data['usuario_verifica'])) {
+                $data['usuario_verifica'] = $currentUser;
+            }
+            if (empty($data['fecha_verifica'])) {
+                $data['fecha_verifica'] = $today;
+            }
         }
         if ($data['accion_cerrar']) {
             $data['cerrada'] = 1;
+            if (empty($data['usuario_cerrado'])) {
+                $data['usuario_cerrado'] = $currentUser;
+            }
+            if (empty($data['fecha_cierre'])) {
+                $data['fecha_cierre'] = $today;
+            }
+            // If closing and no verifica yet, auto-verify as well (generous but safe)
+            if (empty($data['usuario_verifica'])) {
+                $data['usuario_verifica'] = $currentUser;
+                $data['fecha_verifica'] = $today;
+            }
         }
 
         $params = [
@@ -181,5 +200,104 @@ class Formulario extends CatalogFormulario
             );
         }
         $db->desconexion();
+    }
+
+    // --- Quick state machine actions (fuller transitions, 9.28) ---
+    // Called directly via dedicated POST routes. Auto-assigns current user + today.
+    // These bypass the full form and provide one-click verify/close from list.
+
+    public function Verificar($id = null)
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+        Config::initialize();
+
+        $id = $id !== null ? (int)$id : (isset($_POST['id']) ? (int)$_POST['id'] : (int)($_GET['id'] ?? 0));
+        if ($id <= 0) {
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+
+        $db = $this->getDb();
+        // Load minimal current state
+        $db->consultaPreparada("SELECT usuario_verifica, fecha_verifica, cerrada FROM {$this->table} WHERE id = ?", [$id]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+
+        if (!$row) {
+            $_SESSION[$this->flashPrefix . '_flash_success'] = 'Acción no encontrada.';
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+
+        $today = date('Y-m-d');
+        $currentUser = $this->getCurrentUserId();
+
+        $usuarioVer = $row[0] ?: $currentUser;
+        $fechaVer   = $row[1] ?: $today;
+
+        $db = $this->getDb();
+        $db->consultaPreparada(
+            "UPDATE {$this->table} SET usuario_verifica = ?, fecha_verifica = ? WHERE id = ?",
+            [$usuarioVer, $fechaVer, $id]
+        );
+        $db->desconexion();
+
+        $_SESSION[$this->flashPrefix . '_flash_success'] = 'Acción de mejora verificada.';
+        header("Location: {$this->listRoute}");
+        exit;
+    }
+
+    public function Cerrar($id = null)
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+        Config::initialize();
+
+        $id = $id !== null ? (int)$id : (isset($_POST['id']) ? (int)$_POST['id'] : (int)($_GET['id'] ?? 0));
+        if ($id <= 0) {
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+
+        $db = $this->getDb();
+        $db->consultaPreparada("SELECT usuario_verifica, fecha_verifica, cerrada, usuario_cerrado, fecha_cierre FROM {$this->table} WHERE id = ?", [$id]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+
+        if (!$row) {
+            $_SESSION[$this->flashPrefix . '_flash_success'] = 'Acción no encontrada.';
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+
+        $alreadyVerified = !empty($row[0]);
+        if (!$alreadyVerified) {
+            // Enforce: cannot close without prior verification (match form validate)
+            $_SESSION[$this->flashPrefix . '_form_error'] = 'No se puede cerrar sin verificar primero. Use Verificar antes de Cerrar.';
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+
+        $today = date('Y-m-d');
+        $currentUser = $this->getCurrentUserId();
+
+        $usuarioCie = $row[3] ?: $currentUser;
+        $fechaCie   = $row[4] ?: $today;
+
+        $db = $this->getDb();
+        $db->consultaPreparada(
+            "UPDATE {$this->table} SET cerrada = true, usuario_cerrado = ?, fecha_cierre = ? WHERE id = ?",
+            [$usuarioCie, $fechaCie, $id]
+        );
+        $db->desconexion();
+
+        $_SESSION[$this->flashPrefix . '_flash_success'] = 'Acción de mejora cerrada.';
+        header("Location: {$this->listRoute}");
+        exit;
     }
 }

--- a/docker/db-init/data-patches/0038-mejora-state-transitions.sql
+++ b/docker/db-init/data-patches/0038-mejora-state-transitions.sql
@@ -1,0 +1,39 @@
+-- 0038-mejora-state-transitions.sql
+-- Stage 9.28: Ensure rich demo states for full state machine (auto transitions, quick actions)
+-- Idempotent: safe to re-apply.
+
+-- Ensure variety after clean init (Pendiente remains, Verificada, Cerrada)
+UPDATE acciones_mejora SET 
+    usuario_verifica = 1, 
+    fecha_verifica = '2025-01-15'
+WHERE id = 1 AND (usuario_verifica IS NULL OR cerrada IS NOT true);
+
+UPDATE acciones_mejora SET 
+    usuario_verifica = 1, 
+    fecha_verifica = '2025-02-01', 
+    usuario_cerrado = 1, 
+    fecha_cierre = '2025-02-10', 
+    cerrada = true 
+WHERE id = 3;
+
+-- Make sure at least one clear Pendiente exists (id=2 or create if needed)
+UPDATE acciones_mejora SET 
+    usuario_verifica = NULL, 
+    fecha_verifica = NULL,
+    usuario_cerrado = NULL,
+    fecha_cierre = NULL,
+    cerrada = false
+WHERE id = 2;
+
+-- Optional: seed an extra row for testing quick actions if table small (idempotent via description unique-ish)
+INSERT INTO acciones_mejora (tipo, cliente, fecha, descripcion, area, cerrada, usuario_detectado)
+SELECT 1, NULL, '2025-03-01', 'Acción de prueba para transiciones rápidas (Pendiente)', 'Calidad', false, 1
+WHERE NOT EXISTS (
+    SELECT 1 FROM acciones_mejora WHERE descripcion LIKE '%transiciones rápidas%'
+);
+
+-- If the insert happened, we can leave it Pendiente for demo of Verificar button.
+
+INSERT INTO data_patches (filename, applied_at)
+VALUES ('0038-mejora-state-transitions.sql', NOW())
+ON CONFLICT (filename) DO NOTHING;

--- a/index.php
+++ b/index.php
@@ -349,6 +349,10 @@ $router->addRoute('GET', '/admin/mejora/editar/{id}', ['Tuqan\Pages\Mejora\Formu
 $router->addRoute('POST', '/admin/mejora/nuevo', ['Tuqan\Pages\Mejora\Formulario', 'Procesar'], ['before' => 'auth_company']);
 $router->addRoute('POST', '/admin/mejora/editar/{id}', ['Tuqan\Pages\Mejora\Formulario', 'Procesar'], ['before' => 'auth_company']);
 
+// Quick state machine actions (Stage 9.28) — direct verify/close from list
+$router->addRoute('POST', '/admin/mejora/verificar/{id}', ['Tuqan\Pages\Mejora\Formulario', 'Verificar'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/mejora/cerrar/{id}', ['Tuqan\Pages\Mejora\Formulario', 'Cerrar'], ['before' => 'auth_company']);
+
 // Legacy routes for Mejora (from full legacy menu accions: mejora:listado:listado:ver)
 $router->addRoute('GET', '/administracion/mejora/listado/ver', ['Tuqan\Pages\Mejora\Listado', 'ShowPage'], ['before' => 'auth_company']);
 

--- a/reference/COMPACTION-HANDOFF-2026-07-13.md
+++ b/reference/COMPACTION-HANDOFF-2026-07-13.md
@@ -1,0 +1,67 @@
+# Context Compaction Handoff — 2026-07-13
+
+## Current Git State (at time of compaction)
+- Branch: master (clean, no uncommitted changes)
+- Latest commit: 98acea7 Merge pull request #99 (stage 9.27)
+- All work up to and including stage 9.27 has been reviewed, merged, and pulled.
+
+## Last Completed Stage
+- **Stage 9.27 — Mejora deeper: basic state machine**
+  - Added verify/close action checkboxes and computed states (Pendiente/Verificada/Cerrada) in modern Mejora.
+  - Updated Listado/Formulario and templates.
+  - Small patch for demo data.
+  - Plan committed first, full verify, living docs updated.
+  - PR: #99
+
+## Living Documents (source of truth)
+- `.agents/MIGRATION-TODOS.md` — **read this first** on any resume.
+- Suggested Next (as of now):
+  - More Mejora (full state machine/links)
+  - more Formación
+  - Documentación (rich editor)
+  - or broader polish.
+- All stages through 9.27 are marked [x].
+- ~16+ modern modules on the Catalog base (snapshot may lag slightly; actual progress includes Cursos, Inscripciones, etc.).
+- Strong foundation in base classes, relations, trees, and initial workflows.
+
+## Critical Ritual Rules (never skip)
+1. Read `.agents/MIGRATION-TODOS.md` (focus on Suggested Next Legs)
+2. `git checkout master && git pull --ff-only`
+3. New branch: `feat/stage-9.x-descriptive-name`
+4. Write `reference/stage-9.x-...-plan.md` and **commit it first**
+5. `todo_write` for the leg (for 3+ steps)
+6. Docker-only (`docker compose exec app ...`)
+7. Pages/ + templates/ extending Catalog* (use recent patterns for workflows, relations)
+8. Wire modern + legacy routes in index.php when applicable
+9. Extend `scripts/verify-8.6.sh` + append full playbook section to `.agents/STAGE-CHECKLISTS.md`
+10. Update living TODOS + MIGRATION-PLAN
+11. Full clean-room verify (down -v, init-db.sh, psql asserts, verify script, php -l, browser flows)
+12. Logical commits, push, open PR
+
+## Technical Notes to Preserve
+- Mejora now has extensive workflow fields (detectado, verifica, implantacion, cerrado, auditoria links, etc.) and basic state machine (states computed from fields, actions in form).
+- Documentación has content editor (basic texto via contenido_texto), perfiles, workflows.
+- Catalog base is mature with relations, filters, trees (CatalogTree), etc.
+- Data patches up to 0037 (Mejora states).
+- Verification strategy (non-interactive + human gate) has held.
+- Blog article work for recent progress was handled in sibling praderasblog repo in prior compactions.
+
+## When Resuming After Compaction
+- Immediately re-read the full current `.agents/MIGRATION-TODOS.md`
+- Confirm git state (master + clean)
+- Choose next slice (reviewable size, vertical or focused cross-cut; e.g. full Mejora state machine or Documentación rich editor)
+- Open fresh `todo_write`
+- Start with a plan.md committed first on a new feature branch
+
+## Open / Next Areas (high level)
+- Mejora: full state machine (transitions, more integration with Auditorias/Aspectos/Indicadores)
+- Formación: more subs (reqs, ficha personal, etc.)
+- Documentación: rich editor (beyond basic texto), full workflows, formats/plantillas, PDF
+- Aspectos: full matrix + revisiones + cuestionario
+- Auditorías: full execution (plan/horario, findings)
+- Equipos: revisiones + maintenance
+- Procesos: full Árbol editing
+- Cross-cuts: PDF/Excel modernization, questionnaire engine, broader base polish, Twig upgrade
+- Broader polish on early modules or dashboard/main page.
+
+This handoff replaces the older 2026-07-05 version. All prior context is summarized in the living `.agents/` files and reference plans.

--- a/reference/stage-9.28-mejora-full-state-machine-plan.md
+++ b/reference/stage-9.28-mejora-full-state-machine-plan.md
@@ -74,3 +74,21 @@ Follows exact ritual.
 **Execution autonomous per AGENTS.md + testing strategy in STAGE-CHECKLISTS. Plan committed first. Docker-only. If git fails: retry.**
 
 **Plan written on the feature branch (first commit).**
+
+## Execution Evidence (9.28)
+
+- Plan committed first on branch.
+- Clean room: `docker compose --env-file .env.docker down -v && up -d && exec app ./scripts/init-db.sh` — 0038 applied cleanly, 4 Mejora rows with 2 Pendiente / 1 Verificada / 1 Cerrada.
+- php -l: all green (Formulario, Listado, bases, LoginUsuario, index).
+- verify-8.6.sh: passed (including new 9.28 counts + patch check).
+- psql post-init:
+  - 0038 present
+  - mejora_total=4, cerradas=1, verificadas=1, pendientes=2
+  - Sample rows show correct fields populated by prior patches + 0038.
+- Core logic: auto-assign (user 1 + today) on accion_* in form persist; quick Verificar sets verify fields; quick Cerrar enforces verify-first + sets close fields.
+- Templates: estado badge + conditional POST buttons render.
+- Docs: TODOS updated (marked delivered), STAGE-CHECKLISTS has full 9.28 section + commands.
+- Commits: logical (core, templates, patch+docs).
+- Non-interactive gates green. Full browser flow (login → /admin/mejora → quick buttons + form checkboxes → state changes + flashes + DB) is the human gate (per playbook).
+
+All Docker-only. Ready for push + PR review.

--- a/reference/stage-9.28-mejora-full-state-machine-plan.md
+++ b/reference/stage-9.28-mejora-full-state-machine-plan.md
@@ -1,0 +1,76 @@
+# Stage 9.28 — Mejora: full state machine polish (auto transitions + quick actions)
+
+**Status**: Planning phase (plan committed first)
+**Branch target**: `feat/stage-9.28-mejora-full-state-machine`
+**Driver**: Suggested Next after 9.27. "More Mejora (full state machine/links)". Previous 9.27 delivered basic checkboxes + computed states. Now polish to fuller transitions: auto-apply user/date on actions, direct quick-action routes/buttons (mimicking legacy Verificar/Cerrar Accion), visible current estado in form, better UX for workflow.
+
+Follows exact ritual.
+
+## Goals
+1. Add auto-transition logic: when accion_verificar / accion_cerrar (or new quick actions), default usuario_* to current logged-in user and fecha_* to today if not explicitly provided.
+2. Implement dedicated quick transition methods + routes (POST /admin/mejora/verificar/{id}, /admin/mejora/cerrar/{id}) so list can offer one-click state changes.
+3. Display prominent current "Estado" in the edit form (computed or from data).
+4. Enhance list template with conditional quick action buttons (Verificar for Pendiente, Cerrar for Verificada).
+5. Small supporting patch 0038 (better demo states, perhaps a couple more rows with mixed states).
+6. Store id_usuario in session during login (enables real current user for auto-assign) + expose getCurrentUserId() helper in Catalog base.
+7. Extend verify + full 9.28 playbook section.
+8. Update living docs (TODOS flip items, snapshot, suggested next).
+9. Plan first.
+
+## Scope
+**In:**
+- Minor hygiene: LoginUsuario sets $_SESSION['id_usuario']; Catalog* getCurrentUserId() (defaults to 1 for safety).
+- Mejora/Formulario.php: enhance getPostData/persist/validate for auto-dates/users; add public Verificar($id), Cerrar($id) methods.
+- index.php: add the two new POST routes for quick actions (modern only for now).
+- templates/mejora/{listado,formulario}.twig: estado badge in form; conditional quick buttons in list (POST forms or links that post).
+- docker/db-init/data-patches/0038-mejora-state-transitions.sql (idempotent UPDATEs/INSERTs for demo variety).
+- scripts/verify-8.6.sh: add 9.28 counts/asserts.
+- .agents/STAGE-CHECKLISTS.md: new section with todo items + exact commands + evidence template.
+- .agents/MIGRATION-TODOS.md: mark progress, update suggested.
+- This plan.md committed first.
+- Full clean-room run + php -l + browser flows (create + transition via checkbox + via quick button).
+
+**Out:**
+- Legacy colon action remapping (mejora:accmejora:... still fall to LegacyAction; can map later).
+- Full audit trail / history table for changes.
+- Re-open / other transitions.
+- Cross-module auto creation (e.g. from Auditorias findings).
+- Broader links (Aspectos/Indicadores) — note as follow-up.
+- UI for implantacion as separate explicit step (if needed).
+
+## Pattern
+- Builds directly on 9.21/9.25/9.27 (fields + basic machine).
+- Use Catalog helpers + add minimal getCurrentUserId for auto.
+- Quick actions are simple POST that mutate specific fields then redirect (flash "Acción verificada", etc.).
+- State remains derived: Cerrada > Verificada > Pendiente (from fields).
+- Validation remains (cannot close without verifica).
+
+## Data
+- 0038 patch for richer state examples in clean init (ensure 1+ Pendiente, Verificada, Cerrada after init).
+- ON CONFLICT safe.
+
+## Verification
+- Clean: docker compose down -v ; up ; ./docker/db-init/init-db.sh
+- php -l Pages/Mejora/* Pages/Catalog/* Pages/LoginUsuario.php index.php
+- psql asserts for patch + state counts.
+- scripts/verify-8.6.sh (extended)
+- Browser: login, /admin/mejora list (see estados + quick btns), edit one, use checkboxes (auto fill), submit; also use quick Verificar/Cerrar from list; check flashes, DB values, computed labels/estado; no regression on other modules.
+- Post-action: SELECTs show correct usuario_*/fecha_* + cerrada.
+
+## Risks / Notes
+- User id: now properly captured on login (small cross-cut hygiene).
+- Quick actions keep simple (no full form re-render).
+- Dates: server-side today (Y-m-d) for consistency.
+- If no logged id, graceful default to 1 (matches all prior seeds/patches).
+
+## Handoff
+- Advances Mejora to fuller state machine + direct actions.
+- Next suggested: remaining Mejora links/integration, Formación remaining subs, Documentación rich editor, or Aspectos full matrix.
+- All prior Mejora stages (9.4/9.17/9.21/9.25/9.27) now have stronger workflow support.
+
+---
+*Part of the menu-driven modernization (Stage 8.x+ / 9.x).*
+
+**Execution autonomous per AGENTS.md + testing strategy in STAGE-CHECKLISTS. Plan committed first. Docker-only. If git fails: retry.**
+
+**Plan written on the feature branch (first commit).**

--- a/scripts/verify-8.6.sh
+++ b/scripts/verify-8.6.sh
@@ -102,6 +102,11 @@ SELECT COUNT(*) AS mejora_with_verifica FROM acciones_mejora WHERE usuario_verif
 SELECT COUNT(*) AS mejora_cerradas FROM acciones_mejora WHERE cerrada = true;
 SELECT COUNT(*) AS mejora_verificadas FROM acciones_mejora WHERE usuario_verifica IS NOT NULL AND NOT cerrada;
 
+-- 9.28 Mejora full state machine evidence
+SELECT '0038-mejora-state-transitions.sql' AS patch, COUNT(*) FROM data_patches WHERE filename = '0038-mejora-state-transitions.sql';
+SELECT COUNT(*) AS mejora_with_verifica_or_closed FROM acciones_mejora WHERE usuario_verifica IS NOT NULL OR cerrada = true;
+SELECT COUNT(*) AS mejora_pendientes FROM acciones_mejora WHERE COALESCE(cerrada, false) = false AND usuario_verifica IS NULL;
+
 -- 9.5 Formación (Planes) + Documentación evidence
 SELECT COUNT(*) AS plan_formacion_rows FROM plan_formacion;
 SELECT COUNT(*) AS documentos_rows FROM documentos;

--- a/templates/mejora/formulario.twig
+++ b/templates/mejora/formulario.twig
@@ -18,6 +18,27 @@
             <input type="hidden" name="id" value="{{ mejora.id }}">
         {% endif %}
 
+        {% if isEdit %}
+        <div class="form-group" style="margin-bottom: 15px;">
+            <label>Estado actual</label>
+            <div>
+                {% set estado = 'Pendiente' %}
+                {% if mejora.cerrada %}
+                    {% set estado = 'Cerrada' %}
+                {% elseif mejora.usuario_verifica %}
+                    {% set estado = 'Verificada' %}
+                {% endif %}
+                {% if estado == 'Cerrada' %}
+                    <span class="label label-success" style="font-size:14px; padding:4px 10px;">Cerrada</span>
+                {% elseif estado == 'Verificada' %}
+                    <span class="label label-info" style="font-size:14px; padding:4px 10px;">Verificada</span>
+                {% else %}
+                    <span class="label label-default" style="font-size:14px; padding:4px 10px;">Pendiente</span>
+                {% endif %}
+            </div>
+        </div>
+        {% endif %}
+
         <div class="form-group">
             <label for="fecha">Fecha</label>
             <input type="date" class="form-control" id="fecha" name="fecha"
@@ -107,17 +128,17 @@
         </div>
 
         <div class="form-group">
-            <label>Acciones de workflow</label>
+            <label>Acciones de workflow (auto-asigna usuario actual + fecha de hoy si no se especifica)</label>
             <div class="checkbox">
                 <label>
                     <input type="checkbox" name="accion_verificar" value="1">
-                    Marcar como verificada (set Verifica if not set)
+                    Marcar como verificada ahora
                 </label>
             </div>
             <div class="checkbox">
                 <label>
                     <input type="checkbox" name="accion_cerrar" value="1">
-                    Cerrar acción (set Cerrada)
+                    Cerrar acción ahora (requiere verificada)
                 </label>
             </div>
         </div>
@@ -200,7 +221,7 @@
         </div>
 
         <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
-            Acciones de Mejora (Stage 9.4 + 9.17 + 9.21 + 9.25). Remaining workflow fields (Verifica, Implantación, Cierre) + dates added. Full state machine and UI transitions deferred.
+            Acciones de Mejora (Stage 9.4 + 9.17 + 9.21 + 9.25 + 9.27 + 9.28). Full state machine: auto user/date on transitions, quick verify/cerrar buttons, estado display.
         </div>
     </form>
 </div>

--- a/templates/mejora/listado.twig
+++ b/templates/mejora/listado.twig
@@ -52,8 +52,17 @@
                         <td>{{ m.auditoria_label ?? (m.auditoria ?? '-') }}</td>
                         <td>{{ m.area ?? '-' }}</td>
                         <td>{% if m.estado == 'Cerrada' %}<span class="label label-success">Cerrada</span>{% elseif m.estado == 'Verificada' %}<span class="label label-info">Verificada</span>{% else %}<span class="label label-default">Pendiente</span>{% endif %}</td>
-                        <td style="text-align:right;">
+                        <td style="text-align:right; white-space: nowrap;">
                             <a href="/admin/mejora/editar/{{ m.id }}" class="btn btn-xs btn-default">Editar</a>
+                            {% if m.estado == 'Pendiente' %}
+                                <form method="POST" action="/admin/mejora/verificar/{{ m.id }}" style="display:inline; margin-left:4px;">
+                                    <button type="submit" class="btn btn-xs btn-info" title="Marcar como verificada">Verificar</button>
+                                </form>
+                            {% elseif m.estado == 'Verificada' %}
+                                <form method="POST" action="/admin/mejora/cerrar/{{ m.id }}" style="display:inline; margin-left:4px;">
+                                    <button type="submit" class="btn btn-xs btn-success" title="Cerrar acción">Cerrar</button>
+                                </form>
+                            {% endif %}
                         </td>
                     </tr>
                     {% endfor %}
@@ -62,7 +71,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Acciones de Mejora (Stage 9.4 + 9.17 + 9.21 + 9.25 + 9.27). Basic state machine added (Pendiente/Verificada/Cerrada computed from fields). Full transitions and UI actions deferred.
+        Acciones de Mejora (Stage 9.4 + 9.17 + 9.21 + 9.25 + 9.27 + 9.28). Full state machine: quick Verificar/Cerrar buttons + auto user+fecha on transitions. Computed states shown.
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Stage 9.28 — Mejora full state machine polish

Advances the Mejora workflow to a fuller state machine after the basic support in 9.27.

### Changes
- Auto-assign current user + today's date when using accion_verificar / accion_cerrar checkboxes in the edit form (or when using quick actions).
- New dedicated quick transition endpoints: POST /admin/mejora/verificar/{id} and /admin/mejora/cerrar/{id}.
- List now shows conditional **Verificar** (Pendiente items) and **Cerrar** (Verificada items) buttons that POST directly.
- Form shows prominent current **Estado** badge (Cerrada/Verificada/Pendiente).
- Small cross-cut: Login now captures `$_SESSION['id_usuario']`; Catalog bases expose `getCurrentUserId()` (defaults to 1).
- Patch 0038 for varied demo states (2 Pendiente, 1 Verificada, 1 Cerrada).
- Routes, templates, verify-8.6.sh, full playbook in STAGE-CHECKLISTS, TODOS updated.
- Plan committed first. Docker-only. Full clean-room + php -l + psql asserts green.

### Verification
- Non-interactive: down -v, up, init-db.sh (0038 applied), php -l (green), verify-8.6.sh (passes including new asserts), psql state counts.
- Browser (human gate): list quick buttons work, form checkboxes auto-fill, validation prevents invalid close, states compute/display correctly, flashes, no regression.
- See reference/stage-9.28-*-plan.md and STAGE-CHECKLISTS for exact commands/evidence.

Builds on 9.4/9.17/9.21/9.25/9.27 Mejora slices + Catalog base.

Next areas remain: cross links (Auditorias etc.), other verticals.

All per ritual.