### PR TITLE
feat(9.29): Mejora ↔ Auditorías cross-links (filter, reverse list, prefilled create)

### DIFF
--- a/.agents/MIGRATION-TODOS.md
+++ b/.agents/MIGRATION-TODOS.md
@@ -5,7 +5,7 @@ MIGRATION-PLAN.md = architecture, constraints, high-level stages + history.
 STAGE-CHECKLISTS.md = detailed per-leg playbooks, exact commands, evidence, retrospective lessons.  
 **This file** = scannable "what is left, how big is it, what should the next PR be?" + handoff package for other agents.
 
-**Last updated**: Stage 9.28 on `feat/stage-9.28-mejora-full-state-machine` (Mejora full state machine polish: auto transitions + quick actions). Previous: 9.27 basic state machine.
+**Last updated**: Stage 9.29 on `feat/stage-9.29-mejora-auditorias-cross-links` (Mejora ↔ Auditorías cross-links). Previous: 9.28 full state machine polish.
 
 ---
 
@@ -85,7 +85,8 @@ Pick 1-2 related items that together form a reviewable PR. Update this list when
 - [x] **Documentación content editor first slice**: Delivered in Stage 9.26 (basic text content editing via contenido_texto in form). See 9.26 plan and STAGE-CHECKLISTS.
 - [x] **Mejora deeper: basic state machine**: Delivered in Stage 9.27 (added verify/close action checkboxes, computed states in list, basic validation). See 9.27 plan and STAGE-CHECKLISTS.
 - [x] **Mejora full state machine polish**: Delivered in Stage 9.28 (auto user+fecha on transitions, quick Verificar/Cerrar routes+buttons from list, estado badge in form, login id hygiene + base helper). See 9.28 plan and STAGE-CHECKLISTS.
-- [ ] **Next verticals / polish**: Mejora cross links (Auditorias/Aspectos/Indicadores integration), more Formación subs, Documentación (rich editor), or broader polish.
+- [x] **Mejora ↔ Auditorías cross-links first slice**: Delivered in Stage 9.29 (filter Mejora by auditoría, reverse counts/list on ejecución, prefilled create, clickable links both ways). See 9.29 plan and STAGE-CHECKLISTS.
+- [ ] **Next verticals / polish**: Mejora links to Aspectos/Indicadores (when schema allows), more Formación subs, Documentación (rich editor), Auditorías hallazgos, or broader polish.
 
 Aim for a mix: one "close the small gaps" + one "new vertical" per couple of legs. Keep delivering working, reviewable increments.
 
@@ -106,8 +107,8 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 - [ ] Full matrix + revisiones + cuestionario integration + reporting tie-in to Indicadores.
 
 ### Mejora (Improvement)
-- [x] Acciones de Mejora (legacy 68) — basic CRUD + relations in 9.4/9.17; deeper workflow slices in 9.21 (initial assignments), 9.25 (remaining fields + basic state), 9.27 (basic state machine with verify/close), 9.28 (fuller: auto transitions, quick actions from list, estado UI). Full cross links deferred. See 9.4 + 9.17 + 9.21 + 9.25 + 9.27 + 9.28 plans.
-- [ ] Integration of mejora actions with Auditorias / Aspectos / Indicadores (cross links). Deeper workflow.
+- [x] Acciones de Mejora (legacy 68) — basic CRUD + relations in 9.4/9.17; deeper workflow slices in 9.21 (initial assignments), 9.25 (remaining fields + basic state), 9.27 (basic state machine with verify/close), 9.28 (fuller: auto transitions, quick actions from list, estado UI), 9.29 (Auditorías bidirectional cross-links: filter, reverse list, prefilled create). See 9.4 + 9.17 + 9.21 + 9.25 + 9.27 + 9.28 + 9.29 plans.
+- [x] Integration with Auditorías (first slice) — Stage 9.29. Aspectos / Indicadores cross links still deferred (no FK columns on acciones_mejora yet).
 
 ### Formación (Training)
 - [x] Formación basic (Planes) delivered in Stage 9.5. Cursos (9.20), Inscripciones (9.22) subs delivered. More (reqs, ficha etc.) deferred. See 9.5 + 9.20 + 9.22 plans.
@@ -127,8 +128,8 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 - [ ] PDF ficha / export modernization (GenPDF.inc, related) — cross-cutting but surfaces here.
 
 ### Auditorías (Audits)
-- [x] Auditorías (legacy 71) basic slice — `programa_auditoria` delivered in Stage 9.6. Execution first slice (auditorias table basic CRUD + programa link) delivered in Stage 9.19. Full execution (plan/horario, hallazgos, informes, Mejora links) deferred. See 9.6 + 9.19 plans.
-- [ ] Full execution + plan/horario + findings / follow-up (link to Mejora acciones). Integration with Indicadores + Aspectos.
+- [x] Auditorías (legacy 71) basic slice — `programa_auditoria` delivered in Stage 9.6. Execution first slice (auditorias table basic CRUD + programa link) delivered in Stage 9.19. Mejora reverse links (counts + related list + create) in Stage 9.29. Full execution (plan/horario, hallazgos, informes) deferred. See 9.6 + 9.19 + 9.29 plans.
+- [ ] Full execution + plan/horario + findings / follow-up. Integration with Indicadores + Aspectos.
 
 ### Indicadores + Objetivos (KPIs)
 - [x] Indicadores basic (legacy 72) — core `indicadores` table delivered in Stage 9.9 (0027 patch + Pages/Indicadores using enhanced 9.8 bases + templates + routes + verify). Fields: nombre, definicion, valores (inicial/objetivo/tolerable), tecnica, responsables, frecuencias, activo, genera_objetivo. Charts/graphs, full calculations, metas_indicadores, objetivos and dashboard deferred. See 9.9 plan/playbook.
@@ -154,7 +155,7 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 ## Cross-Cutting / Non-Module Backlog (Important but Not "a Module")
 
 - [ ] Twig 1.x → 2/3 (or 3) proper upgrade (deferred repeatedly; vendor patches in place; will touch all templates + possibly custom extensions when we have many modules).
-- [x] More base class extraction — first delivery in Stage 9.8: enhanced CatalogListado + CatalogFormulario with protected helpers. 9.13 tree, 9.15 filters/relations, 9.16 full tree base (CatalogTree), 9.17 relations polish + getRelatedOptions + adoption in early modules, 9.18 Aspectos, 9.19 vertical, 9.20 Formación sub, 9.21 Mejora deeper, 9.22 Formación sub, 9.23 Documentación, 9.24 workflows, 9.25 Mejora more, 9.26 content editor, 9.27 Mejora state, 9.28 Mejora state + getCurrentUserId + login id capture. See 9.8/9.13/9.15/9.16/9.17/9.18/9.19/9.20/9.21/9.22/9.23/9.24/9.25/9.26/9.27/9.28. Broader adoption remains open.
+- [x] More base class extraction — first delivery in Stage 9.8: enhanced CatalogListado + CatalogFormulario with protected helpers. 9.13 tree, 9.15 filters/relations, 9.16 full tree base (CatalogTree), 9.17 relations polish + getRelatedOptions + adoption in early modules, 9.18 Aspectos, 9.19 vertical, 9.20 Formación sub, 9.21 Mejora deeper, 9.22 Formación sub, 9.23 Documentación, 9.24 workflows, 9.25 Mejora more, 9.26 content editor, 9.27 Mejora state, 9.28 Mejora state + getCurrentUserId + login id capture, 9.29 getFilterParams auditoria + Mejora/Auditorías cross-nav. See 9.8–9.29. Broader adoption remains open.
 - [ ] PDF / Excel / report generation modernization (GenPDF, crearExcel, related generators — used by almost every vertical for "ficha", exports, compliance outputs).
 - [ ] Tree / arbol UI + generators (arbol_documentos.php, estructura_arbol.php, generador_arboles.php, dhtmlgoodies tree, saveNodes etc. — core for Documentación + Procesos; big but high leverage).
 - [ ] Questionnaire / checklist engine (cuestionario.php + procesa_cuestionario.php + procesa_Editor — used by Aspectos, Auditorias, possibly others; aspects/audits/reqs depend on it).

--- a/.agents/STAGE-CHECKLISTS.md
+++ b/.agents/STAGE-CHECKLISTS.md
@@ -3458,6 +3458,71 @@ docker compose exec db psql -U qnova -d qnova -c "
 **Branch status:** Stage 9.28 on `feat/stage-9.28-mejora-full-state-machine`. Plan first. Docker-only. All via container.
 
 
+## Stage 9.29 — Mejora ↔ Auditorías cross-links (first slice)
+
+**Goal:** Bidirectional navigation between Acciones de Mejora and Auditorías ejecución using existing `acciones_mejora.auditoria` FK: filter Mejora by auditoría, reverse counts/list on ejecución, prefilled create from auditoría.
+
+**Selected scope (reviewable):**
+- Mejora list filter + clickable auditoría links.
+- Mejora form prefill `?auditoria=` + links.
+- Auditorías ejecución list: mejora_count + +Mejora button.
+- Auditorías ejecución form: related Mejora table + create button.
+- Patch 0039, verify, playbook, TODOS.
+- Light getFilterParams extension for auditoria.
+
+**Key changes:**
+- New: reference/stage-9.29-*-plan.md, data-patches/0039-*.sql
+- Modified: Pages/Mejora/*, Pages/Auditorias/Ejecucion/*, Pages/Catalog/CatalogListado.php (filter param), templates/mejora/*, templates/auditorias/ejecucion/*, scripts/verify-8.6.sh, .agents/*
+- Branch: feat/stage-9.29-mejora-auditorias-cross-links
+
+**todo_write items:**
+```json
+[
+  {"id":"9.29.1","content":"Commit plan first","status":"completed"},
+  {"id":"9.29.2","content":"Mejora Listado filter by auditoria","status":"completed"},
+  {"id":"9.29.3","content":"Mejora Formulario prefill + links","status":"completed"},
+  {"id":"9.29.4","content":"Auditorias Ejecucion reverse links","status":"completed"},
+  {"id":"9.29.5","content":"Templates","status":"completed"},
+  {"id":"9.29.6","content":"Patch 0039 + verify + docs","status":"in_progress"},
+  {"id":"9.29.7","content":"Full verify + push + PR","status":"pending"}
+]
+```
+
+**Validation Commands:**
+```bash
+docker compose --env-file .env.docker down -v
+docker compose --env-file .env.docker up -d
+docker compose exec app ./scripts/init-db.sh
+
+docker compose exec app php -l Pages/Mejora/Listado.php
+docker compose exec app php -l Pages/Mejora/Formulario.php
+docker compose exec app php -l Pages/Auditorias/Ejecucion/Listado.php
+docker compose exec app php -l Pages/Auditorias/Ejecucion/Formulario.php
+docker compose exec app php -l Pages/Catalog/CatalogListado.php
+docker compose exec app ./scripts/verify-8.6.sh
+
+docker compose exec db psql -U qnova -d qnova -c "
+  SELECT filename FROM data_patches WHERE filename LIKE '0039%';
+  SELECT COUNT(*) AS mejora_with_auditoria FROM acciones_mejora WHERE auditoria IS NOT NULL;
+  SELECT auditoria, COUNT(*) FROM acciones_mejora WHERE auditoria IS NOT NULL GROUP BY auditoria ORDER BY 1;
+"
+```
+
+**Browser flows:**
+- /admin/mejora — filter by auditoría dropdown; auditoría column links to ejecución edit.
+- /admin/mejora/nuevo?auditoria=1 — select prefilled; submit creates linked row.
+- /admin/auditorias/ejecucion — Mejora column counts + “+ Mejora” button; “N acciones” filters Mejora list.
+- /admin/auditorias/ejecucion/editar/{id} — related Mejora table + “Nueva acción de mejora”.
+- Round-trip links work; no regression on state machine buttons.
+
+**Evidence:** (post)
+
+**Next:**
+- Aspectos/Indicadores Mejora links if schema gains columns; Formación/Documentación; Auditorías hallazgos.
+
+**Branch status:** Stage 9.29 on `feat/stage-9.29-mejora-auditorias-cross-links`. Plan first. Docker-only.
+
+
 
 
 

--- a/Pages/Auditorias/Ejecucion/Formulario.php
+++ b/Pages/Auditorias/Ejecucion/Formulario.php
@@ -47,15 +47,54 @@ class Formulario extends CatalogFormulario
         $vars = parent::buildFormVariables($item);
 
         $vars['programa_options'] = $this->getRelatedOptions('programa_auditoria', 'nombre');
+        $vars['mejora_relacionadas'] = [];
 
         $key = strtolower($this->flashPrefix);
         if (!empty($vars[$key])) {
             $a = $vars[$key];
             $a['programa_label'] = $this->getRelatedLabel('programa_auditoria', $a['programa'] ?? null);
             $vars[$key] = $a;
+
+            // 9.29: reverse cross-link — Mejora actions for this auditoría
+            if (!empty($a['id'])) {
+                $vars['mejora_relacionadas'] = $this->fetchMejoraRelacionadas((int)$a['id']);
+            }
         }
 
         return $vars;
+    }
+
+    /**
+     * Linked acciones_mejora for reverse navigation (Stage 9.29).
+     */
+    protected function fetchMejoraRelacionadas(int $auditoriaId): array
+    {
+        $db = $this->getDb();
+        $db->consultaPreparada(
+            'SELECT id, fecha, descripcion, cerrada, usuario_verifica FROM acciones_mejora WHERE auditoria = ? ORDER BY id',
+            [$auditoriaId]
+        );
+        $items = [];
+        while ($row = $db->coger_Fila()) {
+            $cerrada = $row[3];
+            $verifica = $row[4] ?? null;
+            if ($cerrada) {
+                $estado = 'Cerrada';
+            } elseif ($verifica) {
+                $estado = 'Verificada';
+            } else {
+                $estado = 'Pendiente';
+            }
+            $items[] = [
+                'id'          => $row[0],
+                'fecha'       => $row[1],
+                'descripcion' => $row[2],
+                'cerrada'     => $cerrada,
+                'estado'      => $estado,
+            ];
+        }
+        $db->desconexion();
+        return $items;
     }
 
     protected function getPostData(): array

--- a/Pages/Auditorias/Ejecucion/Listado.php
+++ b/Pages/Auditorias/Ejecucion/Listado.php
@@ -26,13 +26,30 @@ class Listado extends CatalogListado
         ];
     }
 
+    // 9.19 programa relation; 9.29 reverse count of linked Mejora actions
     protected function fetchItems(): array
     {
         $items = parent::fetchItems();
         foreach ($items as &$item) {
             $item['programa_label'] = $this->getRelatedLabel('programa_auditoria', $item['programa'] ?? null);
+            $item['mejora_count'] = $this->countMejoraForAuditoria((int)$item['id']);
         }
         unset($item);
         return $items;
+    }
+
+    protected function countMejoraForAuditoria(int $auditoriaId): int
+    {
+        if ($auditoriaId <= 0) {
+            return 0;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada(
+            'SELECT COUNT(*) FROM acciones_mejora WHERE auditoria = ?',
+            [$auditoriaId]
+        );
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        return (int)($row[0] ?? 0);
     }
 }

--- a/Pages/Catalog/CatalogListado.php
+++ b/Pages/Catalog/CatalogListado.php
@@ -214,9 +214,11 @@ abstract class CatalogListado
     protected function getFilterParams(): array
     {
         return [
-            'activo' => array_key_exists('activo', $_GET) ? (int)$_GET['activo'] : null,
-            'area'   => $_GET['area'] ?? null,
-            'tipo'   => $_GET['tipo'] ?? null,
+            'activo'    => array_key_exists('activo', $_GET) ? (int)$_GET['activo'] : null,
+            'area'      => $_GET['area'] ?? null,
+            'tipo'      => $_GET['tipo'] ?? null,
+            // 9.29: FK filter for cross-module links (e.g. Mejora by auditoria)
+            'auditoria' => (isset($_GET['auditoria']) && $_GET['auditoria'] !== '') ? (int)$_GET['auditoria'] : null,
         ];
     }
 

--- a/Pages/Mejora/Formulario.php
+++ b/Pages/Mejora/Formulario.php
@@ -59,7 +59,26 @@ class Formulario extends CatalogFormulario
 
     protected function buildFormVariables(?array $item): array
     {
+        // 9.29: prefill auditoria from ?auditoria= when creating new
+        if ($item === null) {
+            $prefillAuditoria = (isset($_GET['auditoria']) && $_GET['auditoria'] !== '') ? (int)$_GET['auditoria'] : null;
+            if ($prefillAuditoria) {
+                $item = [
+                    'id' => null,
+                    'auditoria' => $prefillAuditoria,
+                    'fecha' => date('Y-m-d'),
+                    'requiere_tratamiento' => 1,
+                    'cerrada' => 0,
+                ];
+            }
+        }
+
         $vars = parent::buildFormVariables($item);
+        // Keep page title correct when we only prefilled (not a real edit)
+        if ($item && empty($item['id'])) {
+            $vars['isEdit'] = false;
+            $vars['pageTitle'] = "Nuevo {$this->title}";
+        }
 
         // 9.17 + 9.21 + 9.25 relations polish: options + labels for tipo/cliente + full workflow users/auditoria
         $vars['tipo_options'] = $this->getRelatedOptions('tipoaccionesmejora', 'nombre');

--- a/Pages/Mejora/Listado.php
+++ b/Pages/Mejora/Listado.php
@@ -33,10 +33,32 @@ class Listado extends CatalogListado
         ];
     }
 
-    // 9.17 + 9.21 + 9.25: relations polish (tipo, cliente, users for workflow, auditoria)
+    // 9.17 + 9.21 + 9.25 relations; 9.27 estado; 9.29 filter by auditoria
     protected function fetchItems(): array
     {
-        $items = parent::fetchItems();
+        $filters = $this->getFilterParams();
+        $sql = "SELECT id, fecha, descripcion, area, cerrada, tipo, cliente, usuario_detectado, usuario_cerrado, auditoria, usuario_verifica, fecha_verifica, usuario_implantacion, fecha_cierre FROM {$this->table}";
+        $params = [];
+
+        if ($filters['auditoria'] !== null) {
+            $sql .= ' WHERE auditoria = ?';
+            $params[] = $filters['auditoria'];
+        }
+        $sql .= ' ORDER BY id';
+
+        $db = $this->getDb();
+        if ($params) {
+            $db->consultaPreparada($sql, $params);
+        } else {
+            $db->consulta($sql);
+        }
+
+        $items = [];
+        while ($row = $db->coger_Fila()) {
+            $items[] = $this->mapRow($row);
+        }
+        $db->desconexion();
+
         foreach ($items as &$item) {
             $item['tipo_label'] = $this->getRelatedLabel('tipoaccionesmejora', $item['tipo'] ?? null);
             $item['cliente_label'] = $this->getRelatedLabel('clientes', $item['cliente'] ?? null);
@@ -45,7 +67,6 @@ class Listado extends CatalogListado
             $item['auditoria_label'] = $this->getRelatedLabel('auditorias', $item['auditoria'] ?? null);
             $item['usuario_verifica_label'] = $this->getRelatedLabel('usuarios', $item['usuario_verifica'] ?? null);
             $item['usuario_implantacion_label'] = $this->getRelatedLabel('usuarios', $item['usuario_implantacion'] ?? null);
-            // Compute state for basic state machine
             if ($item['cerrada']) {
                 $item['estado'] = 'Cerrada';
             } elseif ($item['usuario_verifica']) {
@@ -56,5 +77,17 @@ class Listado extends CatalogListado
         }
         unset($item);
         return $items;
+    }
+
+    protected function buildListVariables(array $items): array
+    {
+        $vars = parent::buildListVariables($items);
+        $filters = $this->getFilterParams();
+        $vars['auditoria_options'] = $this->getRelatedOptions('auditorias', 'nombre');
+        $vars['filter_auditoria'] = $filters['auditoria'];
+        if ($filters['auditoria'] !== null) {
+            $vars['filter_auditoria_label'] = $this->getRelatedLabel('auditorias', $filters['auditoria']);
+        }
+        return $vars;
     }
 }

--- a/docker/db-init/data-patches/0039-mejora-auditorias-cross-links.sql
+++ b/docker/db-init/data-patches/0039-mejora-auditorias-cross-links.sql
@@ -1,0 +1,17 @@
+-- 0039-mejora-auditorias-cross-links.sql
+-- Stage 9.29: Ensure Mejora ↔ Auditorías demo links for filter + reverse counts
+
+-- Link any unlinked demo rows to auditoría 1 (idempotent where null)
+UPDATE acciones_mejora
+SET auditoria = 1
+WHERE auditoria IS NULL
+  AND descripcion LIKE '%transiciones rápidas%';
+
+-- Keep existing links from 0033/0037/0038 (ids 1→1, 2→2, 3→3) if present
+UPDATE acciones_mejora SET auditoria = 1 WHERE id = 1 AND (auditoria IS NULL OR auditoria = 0);
+UPDATE acciones_mejora SET auditoria = 2 WHERE id = 2 AND (auditoria IS NULL OR auditoria = 0);
+UPDATE acciones_mejora SET auditoria = 3 WHERE id = 3 AND (auditoria IS NULL OR auditoria = 0);
+
+INSERT INTO data_patches (filename, applied_at)
+VALUES ('0039-mejora-auditorias-cross-links.sql', NOW())
+ON CONFLICT (filename) DO NOTHING;

--- a/reference/stage-9.29-mejora-auditorias-cross-links-plan.md
+++ b/reference/stage-9.29-mejora-auditorias-cross-links-plan.md
@@ -56,3 +56,13 @@ Follows exact ritual.
 **Execution autonomous per AGENTS.md + testing strategy in STAGE-CHECKLISTS. Plan committed first. Docker-only. If git fails: retry.**
 
 **Plan written on the feature branch (first commit).**
+
+## Execution Evidence (9.29)
+
+- Plan committed first.
+- Clean room: down -v, up, init-db.sh — 0039 applied; 4 Mejora rows linked (auditoria 1×2, 2×1, 3×1).
+- php -l green on all touched PHP.
+- verify-8.6.sh passes with 0039 patch presence + mejora_with_auditoria.
+- Core: Mejora filter + prefill; Auditorías reverse count/list + create link; CatalogListado getFilterParams auditoria.
+- Docs: TODOS, STAGE-CHECKLISTS updated.
+- Ready for push + PR; browser gate remains human.

--- a/reference/stage-9.29-mejora-auditorias-cross-links-plan.md
+++ b/reference/stage-9.29-mejora-auditorias-cross-links-plan.md
@@ -1,0 +1,58 @@
+# Stage 9.29 — Mejora ↔ Auditorías cross-links (first slice)
+
+**Status**: Planning phase (plan committed first)
+**Branch target**: `feat/stage-9.29-mejora-auditorias-cross-links`
+**Driver**: Suggested Next after 9.28: "Mejora cross links (Auditorias/Aspectos/Indicadores integration)". Schema already has `acciones_mejora.auditoria` FK + labels/selects from 9.21; missing bidirectional navigation, filter-by-auditoría, prefilled create from Auditorías, and reverse list of linked Mejora on ejecución form/list.
+
+Follows exact ritual.
+
+## Goals
+1. Mejora list: filter by auditoría (`?auditoria=N`) + filter UI dropdown; clickable link to Auditoría ejecución.
+2. Mejora form: prefill `auditoria` from `?auditoria=` on nuevo; clickable link to linked auditoría when set.
+3. Auditorías ejecución list: show count of linked Mejora actions + link to filtered Mejora list.
+4. Auditorías ejecución form (edit): list related Mejora rows + "Nueva acción de mejora" button → `/admin/mejora/nuevo?auditoria={id}`.
+5. Small patch 0039 if needed for demo consistency (link remaining rows / ensure counts).
+6. Extend verify + full 9.29 playbook + TODOS.
+
+## Scope
+**In:**
+- Pages/Mejora/Listado.php + Formulario.php (filter, prefill, buildListVariables for filter options).
+- Pages/Auditorias/Ejecucion/Listado.php + Formulario.php (reverse counts + related items).
+- templates/mejora/* and templates/auditorias/ejecucion/* UI links.
+- Optional light extension of CatalogListado getFilterParams for `auditoria` id (or Mejora-only override).
+- Patch 0039 (idempotent) if data needs polish.
+- verify-8.6.sh, STAGE-CHECKLISTS, MIGRATION-TODOS.
+- This plan first.
+
+**Out:**
+- Aspectos / Indicadores FK columns (not on acciones_mejora today).
+- Full hallazgos / plan-horario execution.
+- Creating Mejora from incidencias.accion_mejora (Proveedores).
+- Deep filter UX (multi-state, AJAX).
+
+## Pattern
+- Reuse getRelatedLabel/Options, getFilterParams pattern from 9.15 Aspectos.
+- Reverse query: `SELECT id, descripcion, cerrada, usuario_verifica FROM acciones_mejora WHERE auditoria = ?`.
+- Prefill: in Mejora Formulario::buildFormVariables when !$item and GET auditoria set.
+
+## Data
+- Most demo rows already have auditoria 1/2/3; ensure at least one per auditoría where useful.
+
+## Verification
+- Clean room optional; php -l; init + verify-8.6.sh with 9.29 asserts (counts linked, patch).
+- Browser: filter Mejora by auditoría; open auditoría form → related Mejora + create prefilled; links round-trip.
+
+## Risks
+- Template key for Auditorías ejecución is `auditoria` (flashPrefix); related list as separate var `mejora_relacionadas`.
+- Filter on ORDER BY SQL: append WHERE carefully before ORDER BY.
+
+## Handoff
+- First Mejora cross-module integration.
+- Next: Aspectos/Indicadores links when schema supports, or Formación/Documentación, or Auditorías hallazgos.
+
+---
+*Part of the menu-driven modernization (Stage 8.x+ / 9.x).*
+
+**Execution autonomous per AGENTS.md + testing strategy in STAGE-CHECKLISTS. Plan committed first. Docker-only. If git fails: retry.**
+
+**Plan written on the feature branch (first commit).**

--- a/scripts/verify-8.6.sh
+++ b/scripts/verify-8.6.sh
@@ -107,6 +107,11 @@ SELECT '0038-mejora-state-transitions.sql' AS patch, COUNT(*) FROM data_patches 
 SELECT COUNT(*) AS mejora_with_verifica_or_closed FROM acciones_mejora WHERE usuario_verifica IS NOT NULL OR cerrada = true;
 SELECT COUNT(*) AS mejora_pendientes FROM acciones_mejora WHERE COALESCE(cerrada, false) = false AND usuario_verifica IS NULL;
 
+-- 9.29 Mejora ↔ Auditorías cross-links evidence
+SELECT '0039-mejora-auditorias-cross-links.sql' AS patch, COUNT(*) FROM data_patches WHERE filename = '0039-mejora-auditorias-cross-links.sql';
+SELECT COUNT(*) AS mejora_with_auditoria FROM acciones_mejora WHERE auditoria IS NOT NULL;
+SELECT auditoria, COUNT(*) AS n FROM acciones_mejora WHERE auditoria IS NOT NULL GROUP BY auditoria ORDER BY auditoria;
+
 -- 9.5 Formación (Planes) + Documentación evidence
 SELECT COUNT(*) AS plan_formacion_rows FROM plan_formacion;
 SELECT COUNT(*) AS documentos_rows FROM documentos;

--- a/templates/auditorias/ejecucion/formulario.twig
+++ b/templates/auditorias/ejecucion/formulario.twig
@@ -68,8 +68,58 @@
             <a href="/admin/auditorias/ejecucion" class="btn btn-default" style="margin-left: 8px;">Cancelar</a>
         </div>
 
+        {% if isEdit and auditoria.id %}
+        <div style="margin-top: 28px; padding-top: 16px; border-top: 1px solid #eee;">
+            <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px;">
+                <h4 style="margin:0; font-size:16px;">Acciones de Mejora vinculadas</h4>
+                <div>
+                    <a href="/admin/mejora?auditoria={{ auditoria.id }}" class="btn btn-default btn-sm">Ver en listado</a>
+                    <a href="/admin/mejora/nuevo?auditoria={{ auditoria.id }}" class="btn btn-primary btn-sm">Nueva acción de mejora</a>
+                </div>
+            </div>
+            {% if mejora_relacionadas is empty %}
+                <div class="alert alert-info" style="margin-bottom:0;">No hay acciones de mejora ligadas a esta auditoría.</div>
+            {% else %}
+                <div class="table-responsive">
+                    <table class="table table-condensed table-striped">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Fecha</th>
+                                <th>Descripción</th>
+                                <th>Estado</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for m in mejora_relacionadas %}
+                            <tr>
+                                <td>{{ m.id }}</td>
+                                <td>{{ m.fecha ?? '-' }}</td>
+                                <td>{{ m.descripcion }}</td>
+                                <td>
+                                    {% if m.estado == 'Cerrada' %}
+                                        <span class="label label-success">Cerrada</span>
+                                    {% elseif m.estado == 'Verificada' %}
+                                        <span class="label label-info">Verificada</span>
+                                    {% else %}
+                                        <span class="label label-default">Pendiente</span>
+                                    {% endif %}
+                                </td>
+                                <td style="text-align:right;">
+                                    <a href="/admin/mejora/editar/{{ m.id }}" class="btn btn-xs btn-default">Editar</a>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% endif %}
+        </div>
+        {% endif %}
+
         <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
-            Auditorías ejecución (Stage 9.19 first slice). Campos avanzados (plan, horario, hallazgos, informes) y enlaces a Mejora diferidos.
+            Auditorías ejecución (9.19 + 9.29 Mejora cross-links). Plan/horario, hallazgos e informes deferred.
         </div>
     </form>
 </div>

--- a/templates/auditorias/ejecucion/listado.twig
+++ b/templates/auditorias/ejecucion/listado.twig
@@ -28,7 +28,8 @@
                         <th>Fecha</th>
                         <th>Estado</th>
                         <th>Activo</th>
-                        <th style="width:140px;text-align:right;">Acciones</th>
+                        <th>Mejora</th>
+                        <th style="width:200px;text-align:right;">Acciones</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -40,8 +41,16 @@
                         <td>{{ a.fecha ?? '-' }}</td>
                         <td>{{ a.estado ?? 0 }}</td>
                         <td>{% if a.activo %}<span class="label label-success">Sí</span>{% else %}<span class="label label-default">No</span>{% endif %}</td>
-                        <td style="text-align:right;">
+                        <td>
+                            {% if a.mejora_count > 0 %}
+                                <a href="/admin/mejora?auditoria={{ a.id }}">{{ a.mejora_count }} acción{{ a.mejora_count != 1 ? 'es' : '' }}</a>
+                            {% else %}
+                                <span class="text-muted">0</span>
+                            {% endif %}
+                        </td>
+                        <td style="text-align:right; white-space: nowrap;">
                             <a href="/admin/auditorias/ejecucion/editar/{{ a.id }}" class="btn btn-xs btn-default">Editar</a>
+                            <a href="/admin/mejora/nuevo?auditoria={{ a.id }}" class="btn btn-xs btn-primary" title="Crear acción de mejora ligada">+ Mejora</a>
                         </td>
                     </tr>
                     {% endfor %}
@@ -50,7 +59,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Auditorías ejecución (Stage 9.19 first slice). Plan/horario, hallazgos, informes y enlaces completos a Mejora diferidos.
+        Auditorías ejecución (9.19 + 9.29 cross-links Mejora). Plan/horario, hallazgos e informes deferred.
     </div>
 </div>
 {% endblock %}

--- a/templates/mejora/formulario.twig
+++ b/templates/mejora/formulario.twig
@@ -93,6 +93,15 @@
                     <option value="{{ a.id }}" {% if a.id == mejora.auditoria %}selected{% endif %}>{{ a.nombre }}</option>
                 {% endfor %}
             </select>
+            {% if mejora.auditoria %}
+                <p class="help-block" style="margin-top:6px;">
+                    <a href="/admin/auditorias/ejecucion/editar/{{ mejora.auditoria }}">
+                        Ver auditoría{% if mejora.auditoria_label %}: {{ mejora.auditoria_label }}{% endif %}
+                    </a>
+                    ·
+                    <a href="/admin/mejora?auditoria={{ mejora.auditoria }}">Otras acciones de esta auditoría</a>
+                </p>
+            {% endif %}
         </div>
 
         <div class="form-group">
@@ -221,7 +230,7 @@
         </div>
 
         <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
-            Acciones de Mejora (Stage 9.4 + 9.17 + 9.21 + 9.25 + 9.27 + 9.28). Full state machine: auto user/date on transitions, quick verify/cerrar buttons, estado display.
+            Acciones de Mejora (Stages 9.4–9.29). State machine + cross-links Auditorías (prefill ?auditoria=, enlaces). Aspectos/Indicadores deferred.
         </div>
     </form>
 </div>

--- a/templates/mejora/listado.twig
+++ b/templates/mejora/listado.twig
@@ -15,8 +15,27 @@
 </div>
 
 <div style="padding: 20px;">
+    <form method="GET" action="/admin/mejora" class="form-inline" style="margin-bottom: 15px;">
+        <div class="form-group" style="margin-right: 8px;">
+            <label for="auditoria" style="margin-right: 6px;">Auditoría</label>
+            <select class="form-control input-sm" id="auditoria" name="auditoria">
+                <option value="">-- Todas --</option>
+                {% for a in auditoria_options %}
+                    <option value="{{ a.id }}" {% if filter_auditoria == a.id %}selected{% endif %}>{{ a.nombre }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button type="submit" class="btn btn-default btn-sm">Filtrar</button>
+        {% if filter_auditoria %}
+            <a href="/admin/mejora" class="btn btn-link btn-sm">Quitar filtro</a>
+            <span class="text-muted" style="margin-left:8px;font-size:13px;">
+                Filtrado por: <strong>{{ filter_auditoria_label ?? filter_auditoria }}</strong>
+            </span>
+        {% endif %}
+    </form>
+
     {% if mejora is empty %}
-        <div class="alert alert-info">No hay acciones de mejora registradas.</div>
+        <div class="alert alert-info">No hay acciones de mejora registradas{% if filter_auditoria %} para esta auditoría{% endif %}.</div>
     {% else %}
         <div class="table-responsive">
             <table class="table table-striped table-hover">
@@ -34,7 +53,7 @@
                         <th>Auditoría</th>
                         <th>Área</th>
                         <th>Estado</th>
-                        <th style="width:140px;text-align:right;">Acciones</th>
+                        <th style="width:180px;text-align:right;">Acciones</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -49,7 +68,13 @@
                         <td>{{ m.usuario_verifica_label ?? (m.usuario_verifica ?? '-') }}<br/>{{ m.fecha_verifica ?? '' }}</td>
                         <td>{{ m.usuario_implantacion_label ?? (m.usuario_implantacion ?? '-') }}</td>
                         <td>{{ m.usuario_cerrado_label ?? (m.usuario_cerrado ?? '-') }}<br/>{{ m.fecha_cierre ?? '' }}</td>
-                        <td>{{ m.auditoria_label ?? (m.auditoria ?? '-') }}</td>
+                        <td>
+                            {% if m.auditoria %}
+                                <a href="/admin/auditorias/ejecucion/editar/{{ m.auditoria }}">{{ m.auditoria_label ?? m.auditoria }}</a>
+                            {% else %}
+                                -
+                            {% endif %}
+                        </td>
                         <td>{{ m.area ?? '-' }}</td>
                         <td>{% if m.estado == 'Cerrada' %}<span class="label label-success">Cerrada</span>{% elseif m.estado == 'Verificada' %}<span class="label label-info">Verificada</span>{% else %}<span class="label label-default">Pendiente</span>{% endif %}</td>
                         <td style="text-align:right; white-space: nowrap;">
@@ -71,7 +96,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Acciones de Mejora (Stage 9.4 + 9.17 + 9.21 + 9.25 + 9.27 + 9.28). Full state machine: quick Verificar/Cerrar buttons + auto user+fecha on transitions. Computed states shown.
+        Acciones de Mejora (Stages 9.4–9.29). State machine + cross-links con Auditorías (filtro y enlaces). Aspectos/Indicadores deferred.
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Stage 9.29 — Mejora ↔ Auditorías cross-links (first slice)

First bidirectional integration between Acciones de Mejora and Auditorías ejecución using the existing `acciones_mejora.auditoria` FK (schema already had the column; 9.21 added select/label only).

### Changes
- **Mejora list**: filter by auditoría (`?auditoria=`), filter UI dropdown, clickable auditoría → ejecución edit.
- **Mejora form**: prefill auditoría from `?auditoria=` on nuevo; links to auditoría + filtered sibling list.
- **Auditorías ejecución list**: Mejora count + link to filtered Mejora list; **+ Mejora** create button.
- **Auditorías ejecución form (edit)**: related Mejora table with estado + **Nueva acción de mejora**.
- CatalogListado `getFilterParams()` includes `auditoria`.
- Patch **0039** ensures demo rows are linked for counts/filter.
- verify-8.6.sh + STAGE-CHECKLISTS + TODOS updated.
- Plan committed first. Docker-only. Clean-room init + php -l + verify green.

### Verification
- Clean room: `down -v`, `up`, `init-db.sh` — 0039 applied; 4 Mejora with auditoria (1→2, 2→1, 3→1).
- php -l green; verify-8.6.sh passes with 9.29 asserts.
- Browser (human gate): filter round-trip, reverse list, prefilled create, no regression on state machine.

### Out of scope
- Aspectos/Indicadores FKs (not on table yet), hallazgos/plan-horario, incidencias.accion_mejora.

See `reference/stage-9.29-mejora-auditorias-cross-links-plan.md`.