### PR TITLE
feat(9.30): Formación cross-links hub (Planes ↔ Cursos ↔ Inscripciones)

### DIFF
--- a/.agents/MIGRATION-TODOS.md
+++ b/.agents/MIGRATION-TODOS.md
@@ -5,7 +5,7 @@ MIGRATION-PLAN.md = architecture, constraints, high-level stages + history.
 STAGE-CHECKLISTS.md = detailed per-leg playbooks, exact commands, evidence, retrospective lessons.  
 **This file** = scannable "what is left, how big is it, what should the next PR be?" + handoff package for other agents.
 
-**Last updated**: Stage 9.29 on `feat/stage-9.29-mejora-auditorias-cross-links` (Mejora ↔ Auditorías cross-links). Previous: 9.28 full state machine polish.
+**Last updated**: Stage 9.30 on `feat/stage-9.30-formacion-cross-links` (Formación Planes↔Cursos↔Inscripciones + light PR sizing note). Previous: 9.29 Mejora↔Auditorías.
 
 ---
 
@@ -27,7 +27,13 @@ STAGE-CHECKLISTS.md = detailed per-leg playbooks, exact commands, evidence, retr
 3. **Marking done**: Only `[x]` items **after merge + verified** (the human who asked does final browser pass on the flows; non-interactive gates must be green).
 4. **Discovery**: During any leg, if you surface a new module, missing accion, extra table, or gap — add it to the right group here *immediately* with a short note + suggested size.
 5. **Handoff to other agents**: The checkboxes + "Suggested Next Legs" shortlist + latest snapshot + links to the just-completed stage plan/checklist section are 90% of what the next agent needs. They still read the top of MIGRATION-PLAN + AGENTS.md once.
-6. **PR sizing**: "the size of PRs we want from now on". One vertical or 2-3 catalogs + patch + routes + verify + docs is the model. Avoid giant refactors.
+6. **PR sizing** (still the 0.1-era sweet spot; suitable for current agents):
+   - **Target**: one clickable outcome the human can exercise in &lt;10 minutes.
+   - **Ceiling**: ~8–20 files, 0–1 data patch, one vertical or one focused cross-cut — not two product stories.
+   - **Hard stop**: if the plan lists &gt;3 independent outcomes, split into two stages.
+   - **Suggested Next line format** (when adding open items):  
+     `9.x — Title · In: … · Out: … · ~N files · patch? yes/no`
+   - Plan.md first remains non-negotiable; docs/verify stay in the same PR.
 
 **Quick navigation**: Use your editor's outline / search for `### ` (area headers) or `[ ]` (open items).
 
@@ -86,7 +92,11 @@ Pick 1-2 related items that together form a reviewable PR. Update this list when
 - [x] **Mejora deeper: basic state machine**: Delivered in Stage 9.27 (added verify/close action checkboxes, computed states in list, basic validation). See 9.27 plan and STAGE-CHECKLISTS.
 - [x] **Mejora full state machine polish**: Delivered in Stage 9.28 (auto user+fecha on transitions, quick Verificar/Cerrar routes+buttons from list, estado badge in form, login id hygiene + base helper). See 9.28 plan and STAGE-CHECKLISTS.
 - [x] **Mejora ↔ Auditorías cross-links first slice**: Delivered in Stage 9.29 (filter Mejora by auditoría, reverse counts/list on ejecución, prefilled create, clickable links both ways). See 9.29 plan and STAGE-CHECKLISTS.
-- [ ] **Next verticals / polish**: Mejora links to Aspectos/Indicadores (when schema allows), more Formación subs, Documentación (rich editor), Auditorías hallazgos, or broader polish.
+- [x] **Formación cross-links hub**: Delivered in Stage 9.30 (Planes curso counts, Cursos filter by plan + inscripción counts, Inscripciones filter by curso, prefills, nested list key fix, nav between subs). See 9.30 plan and STAGE-CHECKLISTS.
+- [ ] **Next** (sized picks — use format above when claiming):  
+  - Documentación estado/filter polish · In: list badges+filter, form estado display · Out: rich HTML editor, binario · ~12 files · patch? small  
+  - Auditorías hallazgos first slice · In: hallazgos table shell linked to ejecución · Out: full plan/horario · ~15 files · patch? yes  
+  - Equipos revisiones shell · In: list+form revisiones · Out: calendario · ~12 files · patch? yes
 
 Aim for a mix: one "close the small gaps" + one "new vertical" per couple of legs. Keep delivering working, reviewable increments.
 
@@ -111,8 +121,8 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 - [x] Integration with Auditorías (first slice) — Stage 9.29. Aspectos / Indicadores cross links still deferred (no FK columns on acciones_mejora yet).
 
 ### Formación (Training)
-- [x] Formación basic (Planes) delivered in Stage 9.5. Cursos (9.20), Inscripciones (9.22) subs delivered. More (reqs, ficha etc.) deferred. See 9.5 + 9.20 + 9.22 plans.
-- [ ] Link to Empleados / RRHH concepts if present in legacy (ficha personal); remaining Formación subs.
+- [x] Formación basic (Planes) delivered in Stage 9.5. Cursos (9.20), Inscripciones (9.22) subs delivered. Cross-links hub (filter/prefill/counts/nav) in Stage 9.30. See 9.5 + 9.20 + 9.22 + 9.30 plans.
+- [ ] Link to Empleados / RRHH concepts if present in legacy (ficha personal); remaining Formación subs beyond the three modern tables.
 
 ### Proveedores (Suppliers)
 - [x] Proveedores (legacy 67) — basic listado + form (nombre + telefono + activo) in Stage 9.2. Followed catalog base + full routes + data patch + verify + playbook. Sub-entities (contactos, incidencias, productos/homologados) deferred to later legs. (See 9.2 plan and STAGE-CHECKLISTS.)

--- a/.agents/STAGE-CHECKLISTS.md
+++ b/.agents/STAGE-CHECKLISTS.md
@@ -3523,6 +3523,29 @@ docker compose exec db psql -U qnova -d qnova -c "
 **Branch status:** Stage 9.29 on `feat/stage-9.29-mejora-auditorias-cross-links`. Plan first. Docker-only.
 
 
+## Stage 9.30 — Formación cross-links hub (Planes ↔ Cursos ↔ Inscripciones)
+
+**Goal:** Bidirectional nav between Planes, Cursos, and Inscripciones (filter, counts, prefilled create) + fix nested list item keys so Cursos/Inscripciones templates receive rows. Light PR-sizing note in TODOS.
+
+**Key changes:** Pages/Formacion/* Listado/Formulario, CatalogListado getFilterParams plan/curso, templates/formacion/**, patch 0040, verify, TODOS sizing, STAGE-CHECKLISTS.
+
+**Validation:**
+```bash
+docker compose --env-file .env.docker exec app ./scripts/init-db.sh   # or clean room
+docker compose exec app php -l Pages/Formacion/Listado.php Pages/Formacion/Cursos/Listado.php Pages/Formacion/Inscripciones/Listado.php Pages/Formacion/Cursos/Formulario.php Pages/Formacion/Inscripciones/Formulario.php Pages/Catalog/CatalogListado.php
+docker compose exec app ./scripts/verify-8.6.sh
+docker compose exec db psql -U qnova -d qnova -c "
+  SELECT filename FROM data_patches WHERE filename LIKE '0040%';
+  SELECT plan, COUNT(*) FROM cursos GROUP BY plan ORDER BY 1;
+  SELECT curso, COUNT(*) FROM alumnos GROUP BY curso ORDER BY 1;
+"
+```
+
+**Browser:** /admin/formacion → curso counts + +Curso; /admin/formacion/cursos?plan=1 filter + inscripción counts; /admin/formacion/inscripciones?curso=1; prefills on nuevo.
+
+**Branch status:** Stage 9.30 on `feat/stage-9.30-formacion-cross-links`. Plan first. Docker-only.
+
+
 
 
 

--- a/Pages/Catalog/CatalogListado.php
+++ b/Pages/Catalog/CatalogListado.php
@@ -217,8 +217,10 @@ abstract class CatalogListado
             'activo'    => array_key_exists('activo', $_GET) ? (int)$_GET['activo'] : null,
             'area'      => $_GET['area'] ?? null,
             'tipo'      => $_GET['tipo'] ?? null,
-            // 9.29: FK filter for cross-module links (e.g. Mejora by auditoria)
+            // 9.29–9.30: FK filters for cross-module links
             'auditoria' => (isset($_GET['auditoria']) && $_GET['auditoria'] !== '') ? (int)$_GET['auditoria'] : null,
+            'plan'      => (isset($_GET['plan']) && $_GET['plan'] !== '') ? (int)$_GET['plan'] : null,
+            'curso'     => (isset($_GET['curso']) && $_GET['curso'] !== '') ? (int)$_GET['curso'] : null,
         ];
     }
 

--- a/Pages/Formacion/Cursos/Formulario.php
+++ b/Pages/Formacion/Cursos/Formulario.php
@@ -48,7 +48,26 @@ class Formulario extends CatalogFormulario
 
     protected function buildFormVariables(?array $item): array
     {
+        // 9.30: prefill plan from ?plan= when creating
+        if ($item === null) {
+            $prefillPlan = (isset($_GET['plan']) && $_GET['plan'] !== '') ? (int)$_GET['plan'] : null;
+            if ($prefillPlan) {
+                $item = [
+                    'id' => null,
+                    'plan' => $prefillPlan,
+                    'activo' => 1,
+                    'estado' => 0,
+                    'calidad' => 0,
+                    'medioambiente' => 0,
+                ];
+            }
+        }
+
         $vars = parent::buildFormVariables($item);
+        if ($item && empty($item['id'])) {
+            $vars['isEdit'] = false;
+            $vars['pageTitle'] = "Nuevo {$this->title}";
+        }
 
         $vars['plan_options'] = $this->getRelatedOptions('plan_formacion', 'nombre');
 

--- a/Pages/Formacion/Cursos/Listado.php
+++ b/Pages/Formacion/Cursos/Listado.php
@@ -27,13 +27,61 @@ class Listado extends CatalogListado
         ];
     }
 
+    // 9.30: filter by plan + reverse inscription counts; fix list key for nested template
     protected function fetchItems(): array
     {
-        $items = parent::fetchItems();
+        $filters = $this->getFilterParams();
+        $sql = "SELECT id, nombre, plan, num_horas, fecha_prevista, activo, estado FROM {$this->table}";
+        $params = [];
+        if ($filters['plan'] !== null) {
+            $sql .= ' WHERE plan = ?';
+            $params[] = $filters['plan'];
+        }
+        $sql .= ' ORDER BY id';
+
+        $db = $this->getDb();
+        if ($params) {
+            $db->consultaPreparada($sql, $params);
+        } else {
+            $db->consulta($sql);
+        }
+        $items = [];
+        while ($row = $db->coger_Fila()) {
+            $items[] = $this->mapRow($row);
+        }
+        $db->desconexion();
+
         foreach ($items as &$item) {
             $item['plan_label'] = $this->getRelatedLabel('plan_formacion', $item['plan'] ?? null);
+            $item['inscripcion_count'] = $this->countInscripcionesForCurso((int)$item['id']);
         }
         unset($item);
         return $items;
+    }
+
+    protected function countInscripcionesForCurso(int $cursoId): int
+    {
+        if ($cursoId <= 0) {
+            return 0;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada('SELECT COUNT(*) FROM alumnos WHERE curso = ?', [$cursoId]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        return (int)($row[0] ?? 0);
+    }
+
+    protected function buildListVariables(array $items): array
+    {
+        $vars = parent::buildListVariables($items);
+        // Nested templateDir is "formacion/cursos"; templates expect "curso"
+        $vars['curso'] = $items;
+        $filters = $this->getFilterParams();
+        $vars['plan_options'] = $this->getRelatedOptions('plan_formacion', 'nombre');
+        $vars['filter_plan'] = $filters['plan'];
+        if ($filters['plan'] !== null) {
+            $vars['filter_plan_label'] = $this->getRelatedLabel('plan_formacion', $filters['plan']);
+        }
+        return $vars;
     }
 }

--- a/Pages/Formacion/Inscripciones/Formulario.php
+++ b/Pages/Formacion/Inscripciones/Formulario.php
@@ -34,7 +34,24 @@ class Formulario extends CatalogFormulario
 
     protected function buildFormVariables(?array $item): array
     {
+        // 9.30: prefill curso from ?curso= when creating
+        if ($item === null) {
+            $prefillCurso = (isset($_GET['curso']) && $_GET['curso'] !== '') ? (int)$_GET['curso'] : null;
+            if ($prefillCurso) {
+                $item = [
+                    'id' => null,
+                    'curso' => $prefillCurso,
+                    'inscrito' => 1,
+                    'verificado' => 0,
+                ];
+            }
+        }
+
         $vars = parent::buildFormVariables($item);
+        if ($item && empty($item['id'])) {
+            $vars['isEdit'] = false;
+            $vars['pageTitle'] = "Nuevo {$this->title}";
+        }
 
         $vars['usuario_options'] = $this->getRelatedOptions('usuarios', 'nombre');
         $vars['curso_options'] = $this->getRelatedOptions('cursos', 'nombre');

--- a/Pages/Formacion/Inscripciones/Listado.php
+++ b/Pages/Formacion/Inscripciones/Listado.php
@@ -25,14 +25,48 @@ class Listado extends CatalogListado
         ];
     }
 
+    // 9.30: filter by curso; fix list key for nested template
     protected function fetchItems(): array
     {
-        $items = parent::fetchItems();
+        $filters = $this->getFilterParams();
+        $sql = "SELECT id, usuario, curso, inscrito, verificado FROM {$this->table}";
+        $params = [];
+        if ($filters['curso'] !== null) {
+            $sql .= ' WHERE curso = ?';
+            $params[] = $filters['curso'];
+        }
+        $sql .= ' ORDER BY id';
+
+        $db = $this->getDb();
+        if ($params) {
+            $db->consultaPreparada($sql, $params);
+        } else {
+            $db->consulta($sql);
+        }
+        $items = [];
+        while ($row = $db->coger_Fila()) {
+            $items[] = $this->mapRow($row);
+        }
+        $db->desconexion();
+
         foreach ($items as &$item) {
             $item['usuario_label'] = $this->getRelatedLabel('usuarios', $item['usuario'] ?? null);
             $item['curso_label'] = $this->getRelatedLabel('cursos', $item['curso'] ?? null);
         }
         unset($item);
         return $items;
+    }
+
+    protected function buildListVariables(array $items): array
+    {
+        $vars = parent::buildListVariables($items);
+        $vars['inscripcion'] = $items;
+        $filters = $this->getFilterParams();
+        $vars['curso_options'] = $this->getRelatedOptions('cursos', 'nombre');
+        $vars['filter_curso'] = $filters['curso'];
+        if ($filters['curso'] !== null) {
+            $vars['filter_curso_label'] = $this->getRelatedLabel('cursos', $filters['curso']);
+        }
+        return $vars;
     }
 }

--- a/Pages/Formacion/Listado.php
+++ b/Pages/Formacion/Listado.php
@@ -25,4 +25,27 @@ class Listado extends CatalogListado
             'medioambiente'  => $row[6],
         ];
     }
+
+    // 9.30: reverse count of cursos per plan
+    protected function fetchItems(): array
+    {
+        $items = parent::fetchItems();
+        foreach ($items as &$item) {
+            $item['curso_count'] = $this->countCursosForPlan((int)$item['id']);
+        }
+        unset($item);
+        return $items;
+    }
+
+    protected function countCursosForPlan(int $planId): int
+    {
+        if ($planId <= 0) {
+            return 0;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada('SELECT COUNT(*) FROM cursos WHERE plan = ?', [$planId]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        return (int)($row[0] ?? 0);
+    }
 }

--- a/docker/db-init/data-patches/0040-formacion-cross-links.sql
+++ b/docker/db-init/data-patches/0040-formacion-cross-links.sql
@@ -1,0 +1,15 @@
+-- 0040-formacion-cross-links.sql
+-- Stage 9.30: Ensure Formación demo FKs for Planes ↔ Cursos ↔ Inscripciones
+-- Idempotent; existing 0032/0034 seeds already link most rows.
+
+UPDATE cursos SET plan = 1 WHERE id = 1 AND (plan IS NULL OR plan = 0);
+UPDATE cursos SET plan = 1 WHERE id = 2 AND (plan IS NULL OR plan = 0);
+UPDATE cursos SET plan = 2 WHERE id = 3 AND (plan IS NULL OR plan = 0);
+
+UPDATE alumnos SET curso = 1 WHERE id = 1 AND (curso IS NULL OR curso = 0);
+UPDATE alumnos SET curso = 2 WHERE id = 2 AND (curso IS NULL OR curso = 0);
+UPDATE alumnos SET curso = 3 WHERE id = 3 AND (curso IS NULL OR curso = 0);
+
+INSERT INTO data_patches (filename, applied_at)
+VALUES ('0040-formacion-cross-links.sql', NOW())
+ON CONFLICT (filename) DO NOTHING;

--- a/reference/stage-9.30-formacion-cross-links-plan.md
+++ b/reference/stage-9.30-formacion-cross-links-plan.md
@@ -1,0 +1,33 @@
+# Stage 9.30 — Formación cross-links hub (Planes ↔ Cursos ↔ Inscripciones)
+
+**Status**: Planning phase (plan committed first)
+**Branch target**: `feat/stage-9.30-formacion-cross-links`
+**Driver**: Suggested Next after 9.29 — switch verticals (Mejora streak ended). Formación has Planes (9.5), Cursos (9.20), Inscripciones (9.22) as isolated catalogs; missing bidirectional nav/filters/prefill (same pattern as Mejora↔Auditorías 9.29). Also fix nested list item keys so Cursos/Inscripciones templates actually receive rows.
+
+**On the flight (light ritual)**: tighten PR sizing note in MIGRATION-TODOS (target one clickable outcome, hard stop second vertical, Suggested Next template line).
+
+## Goals
+1. Planes list: course count + link to filtered cursos; “+ Curso” prefilled.
+2. Cursos list: filter by plan; plan link; inscription count + link; “+ Inscripción” / “+ Curso” with prefills.
+3. Inscripciones list: filter by curso; curso link; filter UI.
+4. Prefill forms: `?plan=` on curso nuevo; `?curso=` on inscripción nuevo.
+5. Fix list variable keys for nested `formacion/cursos` and `formacion/inscripciones` (expose `curso` / `inscripcion`).
+6. Optional tiny patch 0040 if demo links need polish (usually already good).
+7. verify + playbook + TODOS (+ sizing hygiene).
+
+## Scope
+**In:** Pages/Formacion/{Listado,Cursos/*,Inscripciones/*}, templates/formacion/**, CatalogListado getFilterParams plan+curso, docs, verify.
+**Out:** New Formación entities (ficha personal, requisitos puesto), Excel, asistentes workflows, Documentación.
+
+## Sizing (ritual)
+- One product outcome: “navigate Formación plan → courses → inscriptions with filters and prefilled create”.
+- ~10–18 files, 0–1 patch. No second vertical.
+
+## Verification
+- php -l, init if patch, verify asserts (counts by plan/curso), browser round-trip.
+
+## Handoff
+- Next: Documentación rich editor / estado, Auditorías hallazgos, Equipos revisiones, etc.
+
+---
+*Part of Stage 8.x+/9.x modernization. Plan committed first. Docker-only.*

--- a/scripts/verify-8.6.sh
+++ b/scripts/verify-8.6.sh
@@ -112,6 +112,13 @@ SELECT '0039-mejora-auditorias-cross-links.sql' AS patch, COUNT(*) FROM data_pat
 SELECT COUNT(*) AS mejora_with_auditoria FROM acciones_mejora WHERE auditoria IS NOT NULL;
 SELECT auditoria, COUNT(*) AS n FROM acciones_mejora WHERE auditoria IS NOT NULL GROUP BY auditoria ORDER BY auditoria;
 
+-- 9.30 Formación cross-links evidence
+SELECT '0040-formacion-cross-links.sql' AS patch, COUNT(*) FROM data_patches WHERE filename = '0040-formacion-cross-links.sql';
+SELECT COUNT(*) AS cursos_with_plan FROM cursos WHERE plan IS NOT NULL;
+SELECT plan, COUNT(*) AS n FROM cursos WHERE plan IS NOT NULL GROUP BY plan ORDER BY plan;
+SELECT COUNT(*) AS alumnos_with_curso FROM alumnos WHERE curso IS NOT NULL;
+SELECT curso, COUNT(*) AS n FROM alumnos WHERE curso IS NOT NULL GROUP BY curso ORDER BY curso;
+
 -- 9.5 Formación (Planes) + Documentación evidence
 SELECT COUNT(*) AS plan_formacion_rows FROM plan_formacion;
 SELECT COUNT(*) AS documentos_rows FROM documentos;

--- a/templates/formacion/cursos/formulario.twig
+++ b/templates/formacion/cursos/formulario.twig
@@ -32,6 +32,17 @@
                     <option value="{{ p.id }}" {% if p.id == curso.plan %}selected{% endif %}>{{ p.nombre }}</option>
                 {% endfor %}
             </select>
+            {% if curso.plan %}
+                <p class="help-block" style="margin-top:6px;">
+                    <a href="/admin/formacion/editar/{{ curso.plan }}">Ver plan{% if curso.plan_label %}: {{ curso.plan_label }}{% endif %}</a>
+                    ·
+                    <a href="/admin/formacion/cursos?plan={{ curso.plan }}">Otros cursos del plan</a>
+                    {% if isEdit and curso.id %}
+                    ·
+                    <a href="/admin/formacion/inscripciones?curso={{ curso.id }}">Inscripciones</a>
+                    {% endif %}
+                </p>
+            {% endif %}
         </div>
 
         <div class="row">

--- a/templates/formacion/cursos/listado.twig
+++ b/templates/formacion/cursos/listado.twig
@@ -7,7 +7,9 @@
     <div style="display: flex; justify-content: space-between; align-items: center;">
         <h2 style="margin: 0; font-size: 20px;">Cursos de Formación</h2>
         <div>
-            <a href="/admin/formacion/cursos/nuevo" class="btn btn-primary btn-sm">
+            <a href="/admin/formacion" class="btn btn-default btn-sm">Planes</a>
+            <a href="/admin/formacion/inscripciones" class="btn btn-default btn-sm">Inscripciones</a>
+            <a href="/admin/formacion/cursos/nuevo{% if filter_plan %}?plan={{ filter_plan }}{% endif %}" class="btn btn-primary btn-sm">
                 <span class="glyphicon glyphicon-plus"></span> Nuevo Curso
             </a>
         </div>
@@ -15,8 +17,27 @@
 </div>
 
 <div style="padding: 20px;">
+    <form method="GET" action="/admin/formacion/cursos" class="form-inline" style="margin-bottom: 15px;">
+        <div class="form-group" style="margin-right: 8px;">
+            <label for="plan" style="margin-right: 6px;">Plan</label>
+            <select class="form-control input-sm" id="plan" name="plan">
+                <option value="">-- Todos --</option>
+                {% for p in plan_options %}
+                    <option value="{{ p.id }}" {% if filter_plan == p.id %}selected{% endif %}>{{ p.nombre }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button type="submit" class="btn btn-default btn-sm">Filtrar</button>
+        {% if filter_plan %}
+            <a href="/admin/formacion/cursos" class="btn btn-link btn-sm">Quitar filtro</a>
+            <span class="text-muted" style="margin-left:8px;font-size:13px;">
+                Plan: <strong>{{ filter_plan_label ?? filter_plan }}</strong>
+            </span>
+        {% endif %}
+    </form>
+
     {% if curso is empty %}
-        <div class="alert alert-info">No hay cursos registrados.</div>
+        <div class="alert alert-info">No hay cursos registrados{% if filter_plan %} para este plan{% endif %}.</div>
     {% else %}
         <div class="table-responsive">
             <table class="table table-striped table-hover">
@@ -27,9 +48,10 @@
                         <th>Plan</th>
                         <th>Horas</th>
                         <th>Fecha Prevista</th>
+                        <th>Inscripciones</th>
                         <th>Estado</th>
                         <th>Activo</th>
-                        <th style="width:140px;text-align:right;">Acciones</th>
+                        <th style="width:220px;text-align:right;">Acciones</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -37,13 +59,27 @@
                     <tr>
                         <td>{{ c.id }}</td>
                         <td><strong>{{ c.nombre }}</strong></td>
-                        <td>{{ c.plan_label ?? (c.plan ?? '-') }}</td>
+                        <td>
+                            {% if c.plan %}
+                                <a href="/admin/formacion/editar/{{ c.plan }}">{{ c.plan_label ?? c.plan }}</a>
+                            {% else %}
+                                -
+                            {% endif %}
+                        </td>
                         <td>{{ c.num_horas ?? '-' }}</td>
                         <td>{{ c.fecha_prevista ?? '-' }}</td>
+                        <td>
+                            {% if c.inscripcion_count > 0 %}
+                                <a href="/admin/formacion/inscripciones?curso={{ c.id }}">{{ c.inscripcion_count }}</a>
+                            {% else %}
+                                <span class="text-muted">0</span>
+                            {% endif %}
+                        </td>
                         <td>{{ c.estado ?? 0 }}</td>
                         <td>{% if c.activo %}<span class="label label-success">Sí</span>{% else %}<span class="label label-default">No</span>{% endif %}</td>
-                        <td style="text-align:right;">
+                        <td style="text-align:right; white-space: nowrap;">
                             <a href="/admin/formacion/cursos/editar/{{ c.id }}" class="btn btn-xs btn-default">Editar</a>
+                            <a href="/admin/formacion/inscripciones/nuevo?curso={{ c.id }}" class="btn btn-xs btn-primary">+ Inscripción</a>
                         </td>
                     </tr>
                     {% endfor %}
@@ -52,7 +88,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Cursos (Stage 9.20 first Formación sub). Material, responsables, ficha personal y workflows diferidos.
+        Cursos (9.20 + 9.30 cross-links Planes/Inscripciones). Ficha personal y Excel diferidos.
     </div>
 </div>
 {% endblock %}

--- a/templates/formacion/inscripciones/formulario.twig
+++ b/templates/formacion/inscripciones/formulario.twig
@@ -36,6 +36,13 @@
                     <option value="{{ c.id }}" {% if c.id == inscripcion.curso %}selected{% endif %}>{{ c.nombre }}</option>
                 {% endfor %}
             </select>
+            {% if inscripcion.curso %}
+                <p class="help-block" style="margin-top:6px;">
+                    <a href="/admin/formacion/cursos/editar/{{ inscripcion.curso }}">Ver curso{% if inscripcion.curso_label %}: {{ inscripcion.curso_label }}{% endif %}</a>
+                    ·
+                    <a href="/admin/formacion/inscripciones?curso={{ inscripcion.curso }}">Otras inscripciones del curso</a>
+                </p>
+            {% endif %}
         </div>
 
         <div class="form-group">

--- a/templates/formacion/inscripciones/listado.twig
+++ b/templates/formacion/inscripciones/listado.twig
@@ -7,7 +7,9 @@
     <div style="display: flex; justify-content: space-between; align-items: center;">
         <h2 style="margin: 0; font-size: 20px;">Inscripciones a Cursos</h2>
         <div>
-            <a href="/admin/formacion/inscripciones/nuevo" class="btn btn-primary btn-sm">
+            <a href="/admin/formacion" class="btn btn-default btn-sm">Planes</a>
+            <a href="/admin/formacion/cursos" class="btn btn-default btn-sm">Cursos</a>
+            <a href="/admin/formacion/inscripciones/nuevo{% if filter_curso %}?curso={{ filter_curso }}{% endif %}" class="btn btn-primary btn-sm">
                 <span class="glyphicon glyphicon-plus"></span> Nueva Inscripción
             </a>
         </div>
@@ -15,8 +17,27 @@
 </div>
 
 <div style="padding: 20px;">
+    <form method="GET" action="/admin/formacion/inscripciones" class="form-inline" style="margin-bottom: 15px;">
+        <div class="form-group" style="margin-right: 8px;">
+            <label for="curso" style="margin-right: 6px;">Curso</label>
+            <select class="form-control input-sm" id="curso" name="curso">
+                <option value="">-- Todos --</option>
+                {% for c in curso_options %}
+                    <option value="{{ c.id }}" {% if filter_curso == c.id %}selected{% endif %}>{{ c.nombre }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button type="submit" class="btn btn-default btn-sm">Filtrar</button>
+        {% if filter_curso %}
+            <a href="/admin/formacion/inscripciones" class="btn btn-link btn-sm">Quitar filtro</a>
+            <span class="text-muted" style="margin-left:8px;font-size:13px;">
+                Curso: <strong>{{ filter_curso_label ?? filter_curso }}</strong>
+            </span>
+        {% endif %}
+    </form>
+
     {% if inscripcion is empty %}
-        <div class="alert alert-info">No hay inscripciones registradas.</div>
+        <div class="alert alert-info">No hay inscripciones registradas{% if filter_curso %} para este curso{% endif %}.</div>
     {% else %}
         <div class="table-responsive">
             <table class="table table-striped table-hover">
@@ -35,7 +56,13 @@
                     <tr>
                         <td>{{ i.id }}</td>
                         <td>{{ i.usuario_label ?? (i.usuario ?? '-') }}</td>
-                        <td>{{ i.curso_label ?? (i.curso ?? '-') }}</td>
+                        <td>
+                            {% if i.curso %}
+                                <a href="/admin/formacion/cursos/editar/{{ i.curso }}">{{ i.curso_label ?? i.curso }}</a>
+                            {% else %}
+                                -
+                            {% endif %}
+                        </td>
                         <td>{% if i.inscrito %}<span class="label label-success">Sí</span>{% else %}<span class="label label-default">No</span>{% endif %}</td>
                         <td>{% if i.verificado %}<span class="label label-success">Sí</span>{% else %}<span class="label label-default">No</span>{% endif %}</td>
                         <td style="text-align:right;">
@@ -48,7 +75,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Inscripciones (Stage 9.22). Solicitar plaza, asistentes, detalles y Excel diferidos.
+        Inscripciones (9.22 + 9.30 filter by curso + links). Solicitar plaza / Excel diferidos.
     </div>
 </div>
 {% endblock %}

--- a/templates/formacion/listado.twig
+++ b/templates/formacion/listado.twig
@@ -7,6 +7,8 @@
     <div style="display: flex; justify-content: space-between; align-items: center;">
         <h2 style="margin: 0; font-size: 20px;">Planes de Formación</h2>
         <div>
+            <a href="/admin/formacion/cursos" class="btn btn-default btn-sm">Cursos</a>
+            <a href="/admin/formacion/inscripciones" class="btn btn-default btn-sm">Inscripciones</a>
             <a href="/admin/formacion/nuevo" class="btn btn-primary btn-sm">
                 <span class="glyphicon glyphicon-plus"></span> Nuevo Plan
             </a>
@@ -21,7 +23,17 @@
         <div class="table-responsive">
             <table class="table table-striped table-hover">
                 <thead>
-                    <tr><th>ID</th><th>Nombre</th><th>Vigente</th><th>Descripción</th><th>Calidad</th><th>Medio Ambiente</th><th>Estado</th><th style="width:140px;text-align:right;">Acciones</th></tr>
+                    <tr>
+                        <th>ID</th>
+                        <th>Nombre</th>
+                        <th>Vigente</th>
+                        <th>Descripción</th>
+                        <th>Calidad</th>
+                        <th>Medio Ambiente</th>
+                        <th>Cursos</th>
+                        <th>Estado</th>
+                        <th style="width:200px;text-align:right;">Acciones</th>
+                    </tr>
                 </thead>
                 <tbody>
                     {% for f in formacion %}
@@ -32,9 +44,17 @@
                         <td>{{ f.descripcion ?? '-' }}</td>
                         <td>{% if f.calidad %}<span class="label label-info">Sí</span>{% else %}-{% endif %}</td>
                         <td>{% if f.medioambiente %}<span class="label label-info">Sí</span>{% else %}-{% endif %}</td>
+                        <td>
+                            {% if f.curso_count > 0 %}
+                                <a href="/admin/formacion/cursos?plan={{ f.id }}">{{ f.curso_count }} curso{{ f.curso_count != 1 ? 's' : '' }}</a>
+                            {% else %}
+                                <span class="text-muted">0</span>
+                            {% endif %}
+                        </td>
                         <td>{% if f.activo %}<span class="label label-success">Activo</span>{% else %}<span class="label label-default">Inactivo</span>{% endif %}</td>
-                        <td style="text-align:right;">
+                        <td style="text-align:right; white-space: nowrap;">
                             <a href="/admin/formacion/editar/{{ f.id }}" class="btn btn-xs btn-default">Editar</a>
+                            <a href="/admin/formacion/cursos/nuevo?plan={{ f.id }}" class="btn btn-xs btn-primary" title="Nuevo curso en este plan">+ Curso</a>
                         </td>
                     </tr>
                     {% endfor %}
@@ -43,7 +63,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Planes de Formación (Stage 9.5). Cursos, inscripciones, requisitos de puesto y otros flujos de Formación se gestionarán en legs posteriores.
+        Planes de Formación (9.5 + 9.30 cross-links a Cursos e Inscripciones).
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Stage 9.30 — Formación cross-links hub

Switch verticals after Mejora streak. Wire Planes → Cursos → Inscripciones the same way 9.29 did Mejora ↔ Auditorías.

### Product
- **Planes**: curso counts + link to filtered cursos; **+ Curso** prefilled
- **Cursos**: filter by plan; plan link; inscripción counts; **+ Inscripción** prefilled; sub-nav
- **Inscripciones**: filter by curso; curso link; sub-nav
- Prefills: `?plan=` / `?curso=` on nuevo forms

### Hygiene
- Nested list keys: templates expect `curso` / `inscripcion` but base used `templateDir` (`formacion/cursos`) — fixed in Listado overrides so lists actually render rows
- CatalogListado `getFilterParams`: `plan`, `curso`
- Patch **0040** + verify asserts
- **Light ritual**: PR sizing note + sized “Suggested Next” picks in MIGRATION-TODOS

### Verify
- php -l green
- 0040 applied; plan 1→2 cursos, plan 2→1; 1 inscripción per curso
- Browser gate: round-trip filters + prefills

Plan committed first. Docker-only.