### PR TITLE
feat(9.31): Documentación estado labels/filter + /admin reuse note

### DIFF
--- a/.agents/MIGRATION-TODOS.md
+++ b/.agents/MIGRATION-TODOS.md
@@ -5,7 +5,7 @@ MIGRATION-PLAN.md = architecture, constraints, high-level stages + history.
 STAGE-CHECKLISTS.md = detailed per-leg playbooks, exact commands, evidence, retrospective lessons.  
 **This file** = scannable "what is left, how big is it, what should the next PR be?" + handoff package for other agents.
 
-**Last updated**: Stage 9.30 on `feat/stage-9.30-formacion-cross-links` (Formación Planes↔Cursos↔Inscripciones + light PR sizing note). Previous: 9.29 Mejora↔Auditorías.
+**Last updated**: Stage 9.31 on `feat/stage-9.31-documentacion-estado-filter` (Documentación estado labels/filter). Previous: 9.30 Formación cross-links.
 
 ---
 
@@ -34,6 +34,12 @@ STAGE-CHECKLISTS.md = detailed per-leg playbooks, exact commands, evidence, retr
    - **Suggested Next line format** (when adding open items):  
      `9.x — Title · In: … · Out: … · ~N files · patch? yes/no`
    - Plan.md first remains non-negotiable; docs/verify stay in the same PR.
+
+7. **`/admin` path vs reusable modules** (note, not a fork):
+   - Modern routes live under `/admin/*` as a **URL namespace**, not “admin-only product.” Domain code (`Pages/*`, `Catalog*`, tables, workflows) is **Aplicación module logic** and should stay reusable for non-admin entry later.
+   - Today: same classes often also mapped on `/administracion/*`; auth is company login only (legacy menu/perfil permisos **not** re-enforced on Phroute yet).
+   - Debt for later (do not reimplement modules): hard-coded `/admin/...` in templates, fixed `listRoute`, no role-based field/action surface, no dedicated non-admin chrome.
+   - Prefer: keep one class per module; add route aliases / path config / permission filter later — not a second Mejora/Formación stack.
 
 **Quick navigation**: Use your editor's outline / search for `### ` (area headers) or `[ ]` (open items).
 
@@ -93,10 +99,11 @@ Pick 1-2 related items that together form a reviewable PR. Update this list when
 - [x] **Mejora full state machine polish**: Delivered in Stage 9.28 (auto user+fecha on transitions, quick Verificar/Cerrar routes+buttons from list, estado badge in form, login id hygiene + base helper). See 9.28 plan and STAGE-CHECKLISTS.
 - [x] **Mejora ↔ Auditorías cross-links first slice**: Delivered in Stage 9.29 (filter Mejora by auditoría, reverse counts/list on ejecución, prefilled create, clickable links both ways). See 9.29 plan and STAGE-CHECKLISTS.
 - [x] **Formación cross-links hub**: Delivered in Stage 9.30 (Planes curso counts, Cursos filter by plan + inscripción counts, Inscripciones filter by curso, prefills, nested list key fix, nav between subs). See 9.30 plan and STAGE-CHECKLISTS.
-- [ ] **Next** (sized picks — use format above when claiming):  
-  - Documentación estado/filter polish · In: list badges+filter, form estado display · Out: rich HTML editor, binario · ~12 files · patch? small  
+- [x] **Documentación estado/filter polish**: Delivered in Stage 9.31 (estado labels/badges from legacy codes, list filter estado+activo, form select + badge, EstadoHelper, patch 0041). See 9.31 plan and STAGE-CHECKLISTS.
+- [ ] **Next** (sized picks):  
   - Auditorías hallazgos first slice · In: hallazgos table shell linked to ejecución · Out: full plan/horario · ~15 files · patch? yes  
-  - Equipos revisiones shell · In: list+form revisiones · Out: calendario · ~12 files · patch? yes
+  - Equipos revisiones shell · In: list+form revisiones · Out: calendario · ~12 files · patch? yes  
+  - Documentación quick workflow actions · In: revisar/aprobar buttons like Mejora · Out: rich editor · ~12 files · patch? small
 
 Aim for a mix: one "close the small gaps" + one "new vertical" per couple of legs. Keep delivering working, reviewable increments.
 
@@ -133,8 +140,8 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 - [ ] Revisiones + compliance records + maintenance workflows (tie to Auditorias / Mejora).
 
 ### Documentación (Core ISO — high value, likely larger)
-- [x] Documentación initial shell delivered in Stage 9.5. Tree in 9.12. Editor/perfiles in 9.23, workflows in 9.24, content editor (texto) in 9.26. Full rich editor, binario, more, PDF deferred. See 9.5 + 9.12 + 9.23 + 9.24 + 9.26 plans.
-- [ ] Full tree + editor modernization, perfiles, workflows, formats/plantillas.
+- [x] Documentación initial shell delivered in Stage 9.5. Tree in 9.12. Editor/perfiles in 9.23, workflows in 9.24, content editor (texto) in 9.26. Estado labels + list filter in 9.31. Full rich editor, binario, more, PDF deferred. See 9.5 + 9.12 + 9.23 + 9.24 + 9.26 + 9.31 plans.
+- [ ] Full tree + editor modernization, perfiles, workflows, formats/plantillas; quick revise/approve transitions.
 - [ ] PDF ficha / export modernization (GenPDF.inc, related) — cross-cutting but surfaces here.
 
 ### Auditorías (Audits)
@@ -174,6 +181,8 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 - [ ] PHPStan level raises + more strict CI (after more surface is modern).
 - [ ] i18n completeness (catalan partial, more strings in modern templates, Locale/ maintenance).
 - [ ] Auth / permissions matrix full coverage + admin UX for assigning (Permisos module exists but depth?).
+- [ ] Modern route authz: re-apply menu/perfil permisos on Phroute (needed before non-admin multi-role use). See note §7 under How to Use.
+- [ ] Path/prefix config: reduce hard-coded `/admin/...` in templates; listRoute-driven links for future non-admin aliases (same Pages classes).
 - [ ] Main page / dashboard evolution (currently enhanced placeholder + tree; surface indicators, tasks, recent docs).
 
 These often make good "alongside a vertical" work or dedicated legs when a cluster of modules would benefit.

--- a/.agents/STAGE-CHECKLISTS.md
+++ b/.agents/STAGE-CHECKLISTS.md
@@ -3546,6 +3546,23 @@ docker compose exec db psql -U qnova -d qnova -c "
 **Branch status:** Stage 9.30 on `feat/stage-9.30-formacion-cross-links`. Plan first. Docker-only.
 
 
+## Stage 9.31 — Documentación estado/filter polish
+
+**Goal:** Human-readable document estados (legacy integer codes), list filters (estado + activo), form select + badge. Architecture note on `/admin` vs reusable modules.
+
+**Validation:**
+```bash
+docker compose exec app php -l Pages/Documentacion/Listado.php Pages/Documentacion/Formulario.php Pages/Documentacion/EstadoHelper.php Pages/Catalog/CatalogListado.php
+docker compose exec app ./scripts/init-db.sh   # or apply 0041
+docker compose exec app ./scripts/verify-8.6.sh
+docker compose exec db psql -U qnova -d qnova -c "SELECT estado, COUNT(*) FROM documentos GROUP BY estado ORDER BY 1;"
+```
+
+**Browser:** /admin/documentacion — badges, filter Borrador/En vigor; edit form estado select + badge; Árbol link.
+
+**Branch status:** Stage 9.31 on `feat/stage-9.31-documentacion-estado-filter`.
+
+
 
 
 

--- a/Pages/Catalog/CatalogListado.php
+++ b/Pages/Catalog/CatalogListado.php
@@ -221,6 +221,8 @@ abstract class CatalogListado
             'auditoria' => (isset($_GET['auditoria']) && $_GET['auditoria'] !== '') ? (int)$_GET['auditoria'] : null,
             'plan'      => (isset($_GET['plan']) && $_GET['plan'] !== '') ? (int)$_GET['plan'] : null,
             'curso'     => (isset($_GET['curso']) && $_GET['curso'] !== '') ? (int)$_GET['curso'] : null,
+            // 9.31: generic integer estado filter (Documentación, etc.)
+            'estado'    => (isset($_GET['estado']) && $_GET['estado'] !== '') ? (int)$_GET['estado'] : null,
         ];
     }
 

--- a/Pages/Documentacion/EstadoHelper.php
+++ b/Pages/Documentacion/EstadoHelper.php
@@ -1,0 +1,54 @@
+<?php
+namespace Tuqan\Pages\Documentacion;
+
+/**
+ * Document estado codes (legacy constantes.inc.php: iVigor, iBorrador, …).
+ * Kept local to Documentación so Catalog stays generic.
+ */
+class EstadoHelper
+{
+    public static function map(): array
+    {
+        return [
+            1 => 'En vigor',
+            2 => 'Borrador',
+            3 => 'Pend. revisión',
+            4 => 'Revisado',
+            5 => 'Pend. aprobación',
+            6 => 'Histórico',
+        ];
+    }
+
+    public static function label($estado): string
+    {
+        if ($estado === null || $estado === '') {
+            return '—';
+        }
+        $map = self::map();
+        $key = (int)$estado;
+        return $map[$key] ?? ('Estado ' . $key);
+    }
+
+    public static function options(): array
+    {
+        $opts = [];
+        foreach (self::map() as $id => $nombre) {
+            $opts[] = ['id' => $id, 'nombre' => $nombre];
+        }
+        return $opts;
+    }
+
+    /** Bootstrap label class for badges */
+    public static function badgeClass($estado): string
+    {
+        switch ((int)$estado) {
+            case 1: return 'label-success';   // En vigor
+            case 2: return 'label-default';   // Borrador
+            case 3: return 'label-warning';   // Pend. revisión
+            case 4: return 'label-info';      // Revisado
+            case 5: return 'label-primary';   // Pend. aprobación
+            case 6: return 'label-default';   // Histórico
+            default: return 'label-default';
+        }
+    }
+}

--- a/Pages/Documentacion/Formulario.php
+++ b/Pages/Documentacion/Formulario.php
@@ -63,10 +63,11 @@ class Formulario extends CatalogFormulario
     {
         $vars = parent::buildFormVariables($item);
 
-        // 9.23 + 9.24: perfiles + workflows (users for revisar/aprobar)
+        // 9.23 + 9.24: perfiles + workflows; 9.31 estado options/labels
         $vars['tipo_documento_options'] = $this->getRelatedOptions('tipodocumento', 'nombre');
         $vars['area_options'] = $this->getRelatedOptions('areas', 'nombre');
         $vars['usuario_options'] = $this->getRelatedOptions('usuarios', 'nombre');
+        $vars['estado_options'] = EstadoHelper::options();
 
         $key = strtolower($this->flashPrefix);
         if (!empty($vars[$key])) {
@@ -75,6 +76,8 @@ class Formulario extends CatalogFormulario
             $d['area_label'] = $this->getRelatedLabel('areas', $d['area'] ?? null);
             $d['revisado_por_label'] = $this->getRelatedLabel('usuarios', $d['revisado_por'] ?? null);
             $d['aprobado_por_label'] = $this->getRelatedLabel('usuarios', $d['aprobado_por'] ?? null);
+            $d['estado_label'] = EstadoHelper::label($d['estado'] ?? null);
+            $d['estado_badge'] = EstadoHelper::badgeClass($d['estado'] ?? null);
             $vars[$key] = $d;
         }
         return $vars;

--- a/Pages/Documentacion/Listado.php
+++ b/Pages/Documentacion/Listado.php
@@ -26,14 +26,60 @@ class Listado extends CatalogListado
         ];
     }
 
+    // 9.24 labels; 9.31 estado filter + labels
     protected function fetchItems(): array
     {
-        $items = parent::fetchItems();
+        $filters = $this->getFilterParams();
+        $sql = "SELECT id, nombre, codigo, estado, activo, revisado_por, aprobado_por FROM {$this->table}";
+        $params = [];
+        $where = [];
+
+        if ($filters['estado'] !== null) {
+            $where[] = 'estado = ?';
+            $params[] = $filters['estado'];
+        }
+        if (isset($filters['activo']) && $filters['activo'] !== null) {
+            $where[] = 'activo = ?';
+            $params[] = $filters['activo'] ? true : false;
+        }
+        if ($where) {
+            $sql .= ' WHERE ' . implode(' AND ', $where);
+        }
+        $sql .= ' ORDER BY id';
+
+        $db = $this->getDb();
+        if ($params) {
+            $db->consultaPreparada($sql, $params);
+        } else {
+            $db->consulta($sql);
+        }
+        $items = [];
+        while ($row = $db->coger_Fila()) {
+            $items[] = $this->mapRow($row);
+        }
+        $db->desconexion();
+
         foreach ($items as &$item) {
             $item['revisado_por_label'] = $this->getRelatedLabel('usuarios', $item['revisado_por'] ?? null);
             $item['aprobado_por_label'] = $this->getRelatedLabel('usuarios', $item['aprobado_por'] ?? null);
+            $item['estado_label'] = EstadoHelper::label($item['estado'] ?? null);
+            $item['estado_badge'] = EstadoHelper::badgeClass($item['estado'] ?? null);
         }
         unset($item);
         return $items;
+    }
+
+    protected function buildListVariables(array $items): array
+    {
+        $vars = parent::buildListVariables($items);
+        // templateDir is documentacion; keep that key (parent uses templateDir)
+        $filters = $this->getFilterParams();
+        $vars['estado_options'] = EstadoHelper::options();
+        $vars['filter_estado'] = $filters['estado'];
+        $vars['filter_activo'] = $filters['activo'];
+        if ($filters['estado'] !== null) {
+            $vars['filter_estado_label'] = EstadoHelper::label($filters['estado']);
+        }
+        return $vars;
     }
 }

--- a/docker/db-init/data-patches/0041-documentacion-estados.sql
+++ b/docker/db-init/data-patches/0041-documentacion-estados.sql
@@ -1,0 +1,11 @@
+-- 0041-documentacion-estados.sql
+-- Stage 9.31: Mixed demo estados for filter/badges (legacy codes)
+-- 1=En vigor, 2=Borrador, 3=Pend. revisión, 4=Revisado, 5=Pend. aprobación, 6=Histórico
+
+UPDATE documentos SET estado = 2 WHERE id = 1;  -- Borrador
+UPDATE documentos SET estado = 3 WHERE id = 2;  -- Pend. revisión
+UPDATE documentos SET estado = 1 WHERE id = 3;  -- En vigor
+
+INSERT INTO data_patches (filename, applied_at)
+VALUES ('0041-documentacion-estados.sql', NOW())
+ON CONFLICT (filename) DO NOTHING;

--- a/reference/stage-9.31-documentacion-estado-filter-plan.md
+++ b/reference/stage-9.31-documentacion-estado-filter-plan.md
@@ -1,0 +1,24 @@
+# Stage 9.31 — Documentación estado/filter polish
+
+**Status**: Planning phase (plan committed first)
+**Branch**: `feat/stage-9.31-documentacion-estado-filter`
+**Driver**: Sized next after 9.30. Also capture architecture note: `/admin` is modern URL namespace; Catalog/Pages domain is reusable; authz + path hardcoding still open.
+
+## Goals
+1. Map documento `estado` integers (legacy constants) to human labels + badges in list/form.
+2. Filter list by estado (+ keep activo filter option if cheap).
+3. Form: estado as select (not raw number), show badge.
+4. Nav link to Árbol; patch 0041 for mixed demo estados.
+5. Note in MIGRATION-TODOS: admin path vs reusable modules (no code fork yet).
+6. verify + playbook + TODOS.
+
+## Out
+- Rich HTML editor, binario, full approval transitions/quick buttons (can follow like Mejora 9.28).
+- Permission gates on Phroute.
+
+## Sizing
+- One outcome: “see and filter documents by estado with readable labels”.
+- ~10–14 files, 1 small patch.
+
+---
+*Plan committed first. Docker-only.*

--- a/scripts/verify-8.6.sh
+++ b/scripts/verify-8.6.sh
@@ -119,6 +119,11 @@ SELECT plan, COUNT(*) AS n FROM cursos WHERE plan IS NOT NULL GROUP BY plan ORDE
 SELECT COUNT(*) AS alumnos_with_curso FROM alumnos WHERE curso IS NOT NULL;
 SELECT curso, COUNT(*) AS n FROM alumnos WHERE curso IS NOT NULL GROUP BY curso ORDER BY curso;
 
+-- 9.31 Documentación estado filter evidence
+SELECT '0041-documentacion-estados.sql' AS patch, COUNT(*) FROM data_patches WHERE filename = '0041-documentacion-estados.sql';
+SELECT estado, COUNT(*) AS n FROM documentos WHERE estado IS NOT NULL GROUP BY estado ORDER BY estado;
+SELECT COUNT(*) AS documentos_con_estado FROM documentos WHERE estado IS NOT NULL;
+
 -- 9.5 Formación (Planes) + Documentación evidence
 SELECT COUNT(*) AS plan_formacion_rows FROM plan_formacion;
 SELECT COUNT(*) AS documentos_rows FROM documentos;

--- a/templates/documentacion/formulario.twig
+++ b/templates/documentacion/formulario.twig
@@ -35,10 +35,25 @@
             <textarea class="form-control" id="contenido" name="contenido" rows="8">{{ documento.contenido ?? '' }}</textarea>
         </div>
 
+        {% if isEdit and documento.estado is not null %}
+        <div class="form-group">
+            <label>Estado actual</label>
+            <div>
+                <span class="label {{ documento.estado_badge|default('label-default') }}" style="font-size:14px;padding:4px 10px;">
+                    {{ documento.estado_label ?? documento.estado }}
+                </span>
+            </div>
+        </div>
+        {% endif %}
+
         <div class="form-group">
             <label for="estado">Estado</label>
-            <input type="number" class="form-control" id="estado" name="estado"
-                   value="{{ documento.estado ?? '' }}">
+            <select class="form-control" id="estado" name="estado">
+                <option value="">-- Seleccionar --</option>
+                {% for e in estado_options %}
+                    <option value="{{ e.id }}" {% if e.id == documento.estado %}selected{% endif %}>{{ e.nombre }}</option>
+                {% endfor %}
+            </select>
         </div>
 
         <div class="form-group">
@@ -162,7 +177,7 @@
         </div>
 
         <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
-            Documentación (Stage 9.5 + 9.23 + 9.24 + 9.26). Basic content editor (texto) added via contenido_texto. Full rich editor, workflows integration, etc. deferred.
+            Documentación (9.5–9.26 + 9.31). Estado con etiquetas (En vigor / Borrador / …). Rich editor / binario deferred.
         </div>
     </form>
 </div>

--- a/templates/documentacion/listado.twig
+++ b/templates/documentacion/listado.twig
@@ -7,6 +7,7 @@
     <div style="display: flex; justify-content: space-between; align-items: center;">
         <h2 style="margin: 0; font-size: 20px;">Documentación</h2>
         <div>
+            <a href="/admin/documentacion/arbol" class="btn btn-default btn-sm">Árbol</a>
             <a href="/admin/documentacion/nuevo" class="btn btn-primary btn-sm">
                 <span class="glyphicon glyphicon-plus"></span> Nuevo Documento
             </a>
@@ -15,17 +16,46 @@
 </div>
 
 <div style="padding: 20px;">
-    <div class="alert alert-warning" style="margin-bottom:15px;font-size:13px;">
-        Shell inicial de Documentación (Stage 9.5). El árbol de documentos, editor, flujos de aprobación, permisos por perfil y la mayoría de sub-módulos (manual, política, vigentes, borradores, formatos, etc.) permanecen en legacy por ahora.
-    </div>
+    <form method="GET" action="/admin/documentacion" class="form-inline" style="margin-bottom: 15px;">
+        <div class="form-group" style="margin-right: 8px;">
+            <label for="estado" style="margin-right: 6px;">Estado</label>
+            <select class="form-control input-sm" id="estado" name="estado">
+                <option value="">-- Todos --</option>
+                {% for e in estado_options %}
+                    <option value="{{ e.id }}" {% if filter_estado is not null and filter_estado == e.id %}selected{% endif %}>{{ e.nombre }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="form-group" style="margin-right: 8px;">
+            <label for="activo" style="margin-right: 6px;">Activo</label>
+            <select class="form-control input-sm" id="activo" name="activo">
+                <option value="">-- Todos --</option>
+                <option value="1" {% if filter_activo is not null and filter_activo == 1 %}selected{% endif %}>Sí</option>
+                <option value="0" {% if filter_activo is not null and filter_activo == 0 %}selected{% endif %}>No</option>
+            </select>
+        </div>
+        <button type="submit" class="btn btn-default btn-sm">Filtrar</button>
+        {% if filter_estado is not null or filter_activo is not null %}
+            <a href="/admin/documentacion" class="btn btn-link btn-sm">Quitar filtros</a>
+        {% endif %}
+    </form>
 
     {% if documentacion is empty %}
-        <div class="alert alert-info">No hay documentos registrados en la vista básica.</div>
+        <div class="alert alert-info">No hay documentos{% if filter_estado is not null or filter_activo is not null %} con estos filtros{% endif %}.</div>
     {% else %}
         <div class="table-responsive">
             <table class="table table-striped table-hover">
                 <thead>
-                    <tr><th>ID</th><th>Nombre</th><th>Código</th><th>Estado</th><th>Revisado por</th><th>Aprobado por</th><th>Activo</th><th style="width:140px;text-align:right;">Acciones</th></tr>
+                    <tr>
+                        <th>ID</th>
+                        <th>Nombre</th>
+                        <th>Código</th>
+                        <th>Estado</th>
+                        <th>Revisado por</th>
+                        <th>Aprobado por</th>
+                        <th>Activo</th>
+                        <th style="width:140px;text-align:right;">Acciones</th>
+                    </tr>
                 </thead>
                 <tbody>
                     {% for d in documentacion %}
@@ -33,7 +63,9 @@
                         <td>{{ d.id }}</td>
                         <td><strong>{{ d.nombre }}</strong></td>
                         <td>{{ d.codigo ?? '-' }}</td>
-                        <td>{{ d.estado ?? '-' }}</td>
+                        <td>
+                            <span class="label {{ d.estado_badge|default('label-default') }}">{{ d.estado_label ?? (d.estado ?? '—') }}</span>
+                        </td>
                         <td>{{ d.revisado_por_label ?? (d.revisado_por ?? '-') }}</td>
                         <td>{{ d.aprobado_por_label ?? (d.aprobado_por ?? '-') }}</td>
                         <td>{% if d.activo %}<span class="label label-success">Activo</span>{% else %}<span class="label label-default">Inactivo</span>{% endif %}</td>
@@ -47,7 +79,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Documentación (Stage 9.5 + 9.23 + 9.24). Workflows (revisado/aprobado por) added. Full editor and more deferred.
+        Documentación (9.5–9.26 + 9.31 estado labels/filter). Rich editor / binario deferred.
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Stage 9.31 — Documentación estado/filter polish

### Product
- Document list: human-readable **estado** badges (En vigor, Borrador, Pend. revisión, …) using legacy integer codes
- Filters: estado + activo
- Form: estado **select** (not raw number) + current-state badge
- Link to Árbol from list header
- `EstadoHelper` + patch **0041** for mixed demo states

### Architecture note (as requested)
Captured in `MIGRATION-TODOS.md` §7 + cross-cut backlog:
- `/admin/*` is modern **URL namespace**, not admin-only product
- Catalog/Pages domain stays **reusable** for non-admin later
- Debt: hard-coded paths, no Phroute permisos yet — prefer route aliases later, not module forks

### Verify
php -l green · 0041 applied · estados 2/3/1 on demo rows · verify script green

Browser: `/admin/documentacion` filters + badges; edit form select.

Plan committed first. Docker-only.