### PR TITLE
feat(9.32): Auditorías hallazgos first slice

### DIFF
--- a/.agents/MIGRATION-TODOS.md
+++ b/.agents/MIGRATION-TODOS.md
@@ -5,7 +5,7 @@ MIGRATION-PLAN.md = architecture, constraints, high-level stages + history.
 STAGE-CHECKLISTS.md = detailed per-leg playbooks, exact commands, evidence, retrospective lessons.  
 **This file** = scannable "what is left, how big is it, what should the next PR be?" + handoff package for other agents.
 
-**Last updated**: Stage 9.31 on `feat/stage-9.31-documentacion-estado-filter` (Documentación estado labels/filter). Previous: 9.30 Formación cross-links.
+**Last updated**: Stage 9.32 on `feat/stage-9.32-auditorias-hallazgos` (Auditorías hallazgos first slice). Previous: 9.31 Documentación estado.
 
 ---
 
@@ -100,10 +100,11 @@ Pick 1-2 related items that together form a reviewable PR. Update this list when
 - [x] **Mejora ↔ Auditorías cross-links first slice**: Delivered in Stage 9.29 (filter Mejora by auditoría, reverse counts/list on ejecución, prefilled create, clickable links both ways). See 9.29 plan and STAGE-CHECKLISTS.
 - [x] **Formación cross-links hub**: Delivered in Stage 9.30 (Planes curso counts, Cursos filter by plan + inscripción counts, Inscripciones filter by curso, prefills, nested list key fix, nav between subs). See 9.30 plan and STAGE-CHECKLISTS.
 - [x] **Documentación estado/filter polish**: Delivered in Stage 9.31 (estado labels/badges from legacy codes, list filter estado+activo, form select + badge, EstadoHelper, patch 0041). See 9.31 plan and STAGE-CHECKLISTS.
+- [x] **Auditorías hallazgos first slice**: Delivered in Stage 9.32 (`hallazgos_auditoria` table, list/form, filter by auditoría, reverse links on ejecución, optional Mejora FK, patch 0042). See 9.32 plan and STAGE-CHECKLISTS.
 - [ ] **Next** (sized picks):  
-  - Auditorías hallazgos first slice · In: hallazgos table shell linked to ejecución · Out: full plan/horario · ~15 files · patch? yes  
   - Equipos revisiones shell · In: list+form revisiones · Out: calendario · ~12 files · patch? yes  
-  - Documentación quick workflow actions · In: revisar/aprobar buttons like Mejora · Out: rich editor · ~12 files · patch? small
+  - Documentación quick workflow actions · In: revisar/aprobar buttons like Mejora · Out: rich editor · ~12 files · patch? small  
+  - Auditorías plan/horario · In: horario_auditoria shell · Out: informes · ~12 files · patch? yes
 
 Aim for a mix: one "close the small gaps" + one "new vertical" per couple of legs. Keep delivering working, reviewable increments.
 
@@ -145,8 +146,8 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 - [ ] PDF ficha / export modernization (GenPDF.inc, related) — cross-cutting but surfaces here.
 
 ### Auditorías (Audits)
-- [x] Auditorías (legacy 71) basic slice — `programa_auditoria` delivered in Stage 9.6. Execution first slice (auditorias table basic CRUD + programa link) delivered in Stage 9.19. Mejora reverse links (counts + related list + create) in Stage 9.29. Full execution (plan/horario, hallazgos, informes) deferred. See 9.6 + 9.19 + 9.29 plans.
-- [ ] Full execution + plan/horario + findings / follow-up. Integration with Indicadores + Aspectos.
+- [x] Auditorías (legacy 71) basic slice — `programa_auditoria` delivered in Stage 9.6. Execution first slice (auditorias table basic CRUD + programa link) delivered in Stage 9.19. Mejora reverse links in Stage 9.29. Hallazgos first slice (`hallazgos_auditoria` + CRUD + links) in Stage 9.32. Plan/horario e informes still deferred. See 9.6 + 9.19 + 9.29 + 9.32 plans.
+- [ ] Full execution + plan/horario + informes / deeper follow-up. Integration with Indicadores + Aspectos.
 
 ### Indicadores + Objetivos (KPIs)
 - [x] Indicadores basic (legacy 72) — core `indicadores` table delivered in Stage 9.9 (0027 patch + Pages/Indicadores using enhanced 9.8 bases + templates + routes + verify). Fields: nombre, definicion, valores (inicial/objetivo/tolerable), tecnica, responsables, frecuencias, activo, genera_objetivo. Charts/graphs, full calculations, metas_indicadores, objetivos and dashboard deferred. See 9.9 plan/playbook.

--- a/.agents/STAGE-CHECKLISTS.md
+++ b/.agents/STAGE-CHECKLISTS.md
@@ -3563,6 +3563,23 @@ docker compose exec db psql -U qnova -d qnova -c "SELECT estado, COUNT(*) FROM d
 **Branch status:** Stage 9.31 on `feat/stage-9.31-documentacion-estado-filter`.
 
 
+## Stage 9.32 — Auditorías hallazgos first slice
+
+**Goal:** Modern hallazgos CRUD linked to auditoría ejecución (new table; no legacy hallazgos table in clean schema). Optional Mejora link. Reverse counts on ejecución.
+
+**Validation:**
+```bash
+docker compose exec app ./scripts/init-db.sh
+docker compose exec app php -l Pages/Auditorias/Hallazgos/Listado.php Pages/Auditorias/Hallazgos/Formulario.php Pages/Auditorias/Ejecucion/Listado.php Pages/Auditorias/Ejecucion/Formulario.php index.php
+docker compose exec app ./scripts/verify-8.6.sh
+docker compose exec db psql -U qnova -d qnova -c "SELECT COUNT(*) FROM hallazgos_auditoria; SELECT auditoria, COUNT(*) FROM hallazgos_auditoria GROUP BY 1;"
+```
+
+**Browser:** /admin/auditorias/hallazgos; filter by auditoría; create from ejecución “+ Hallazgo”; edit form with Mejora select; ejecución form shows hallazgos section.
+
+**Branch status:** Stage 9.32 on `feat/stage-9.32-auditorias-hallazgos`.
+
+
 
 
 

--- a/Pages/Auditorias/Ejecucion/Formulario.php
+++ b/Pages/Auditorias/Ejecucion/Formulario.php
@@ -48,6 +48,7 @@ class Formulario extends CatalogFormulario
 
         $vars['programa_options'] = $this->getRelatedOptions('programa_auditoria', 'nombre');
         $vars['mejora_relacionadas'] = [];
+        $vars['hallazgos_relacionados'] = [];
 
         $key = strtolower($this->flashPrefix);
         if (!empty($vars[$key])) {
@@ -55,9 +56,10 @@ class Formulario extends CatalogFormulario
             $a['programa_label'] = $this->getRelatedLabel('programa_auditoria', $a['programa'] ?? null);
             $vars[$key] = $a;
 
-            // 9.29: reverse cross-link — Mejora actions for this auditoría
+            // 9.29 Mejora + 9.32 hallazgos reverse links
             if (!empty($a['id'])) {
                 $vars['mejora_relacionadas'] = $this->fetchMejoraRelacionadas((int)$a['id']);
+                $vars['hallazgos_relacionados'] = $this->fetchHallazgosRelacionados((int)$a['id']);
             }
         }
 
@@ -95,6 +97,35 @@ class Formulario extends CatalogFormulario
         }
         $db->desconexion();
         return $items;
+    }
+
+    /**
+     * Linked hallazgos_auditoria (Stage 9.32).
+     */
+    protected function fetchHallazgosRelacionados(int $auditoriaId): array
+    {
+        try {
+            $db = $this->getDb();
+            $db->consultaPreparada(
+                'SELECT id, fecha, descripcion, tipo, gravedad, cerrado FROM hallazgos_auditoria WHERE auditoria = ? ORDER BY id',
+                [$auditoriaId]
+            );
+            $items = [];
+            while ($row = $db->coger_Fila()) {
+                $items[] = [
+                    'id'          => $row[0],
+                    'fecha'       => $row[1],
+                    'descripcion' => $row[2],
+                    'tipo'        => $row[3],
+                    'gravedad'    => $row[4],
+                    'cerrado'     => $row[5],
+                ];
+            }
+            $db->desconexion();
+            return $items;
+        } catch (\Throwable $e) {
+            return [];
+        }
     }
 
     protected function getPostData(): array

--- a/Pages/Auditorias/Ejecucion/Listado.php
+++ b/Pages/Auditorias/Ejecucion/Listado.php
@@ -26,13 +26,14 @@ class Listado extends CatalogListado
         ];
     }
 
-    // 9.19 programa relation; 9.29 reverse count of linked Mejora actions
+    // 9.19 programa; 9.29 Mejora count; 9.32 hallazgos count
     protected function fetchItems(): array
     {
         $items = parent::fetchItems();
         foreach ($items as &$item) {
             $item['programa_label'] = $this->getRelatedLabel('programa_auditoria', $item['programa'] ?? null);
             $item['mejora_count'] = $this->countMejoraForAuditoria((int)$item['id']);
+            $item['hallazgo_count'] = $this->countHallazgosForAuditoria((int)$item['id']);
         }
         unset($item);
         return $items;
@@ -51,5 +52,26 @@ class Listado extends CatalogListado
         $row = $db->coger_Fila();
         $db->desconexion();
         return (int)($row[0] ?? 0);
+    }
+
+    protected function countHallazgosForAuditoria(int $auditoriaId): int
+    {
+        if ($auditoriaId <= 0) {
+            return 0;
+        }
+        $db = $this->getDb();
+        // Table may not exist until patch 0042; fail soft for older DBs mid-migration
+        try {
+            $db->consultaPreparada(
+                'SELECT COUNT(*) FROM hallazgos_auditoria WHERE auditoria = ?',
+                [$auditoriaId]
+            );
+            $row = $db->coger_Fila();
+            $db->desconexion();
+            return (int)($row[0] ?? 0);
+        } catch (\Throwable $e) {
+            $db->desconexion();
+            return 0;
+        }
     }
 }

--- a/Pages/Auditorias/Hallazgos/Formulario.php
+++ b/Pages/Auditorias/Hallazgos/Formulario.php
@@ -1,0 +1,152 @@
+<?php
+namespace Tuqan\Pages\Auditorias\Hallazgos;
+use Tuqan\Pages\Catalog\CatalogFormulario;
+
+class Formulario extends CatalogFormulario
+{
+    protected string $table        = 'hallazgos_auditoria';
+    protected string $title        = 'Hallazgo de Auditoría';
+    protected string $templateDir  = 'auditorias/hallazgos';
+    protected string $flashPrefix  = 'hallazgo';
+    protected string $listRoute    = '/admin/auditorias/hallazgos';
+
+    protected function getSelectForForm(): string
+    {
+        return "SELECT id, auditoria, fecha, descripcion, tipo, gravedad, cerrado, accion_mejora, activo, observaciones FROM {$this->table} WHERE id = ?";
+    }
+
+    protected function loadItem($id): ?array
+    {
+        if ($id <= 0) {
+            return null;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada($this->getSelectForForm(), [$id]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row) {
+            return null;
+        }
+        return [
+            'id'            => $row[0],
+            'auditoria'     => $row[1] ?? null,
+            'fecha'         => $row[2] ?? null,
+            'descripcion'   => $row[3],
+            'tipo'          => $row[4] ?? 'observacion',
+            'gravedad'      => $row[5] ?? 'menor',
+            'cerrado'       => $row[6],
+            'accion_mejora' => $row[7] ?? null,
+            'activo'        => $row[8],
+            'observaciones' => $row[9] ?? null,
+        ];
+    }
+
+    protected function buildFormVariables(?array $item): array
+    {
+        if ($item === null) {
+            $prefill = (isset($_GET['auditoria']) && $_GET['auditoria'] !== '') ? (int)$_GET['auditoria'] : null;
+            if ($prefill) {
+                $item = [
+                    'id' => null,
+                    'auditoria' => $prefill,
+                    'fecha' => date('Y-m-d'),
+                    'tipo' => 'observacion',
+                    'gravedad' => 'menor',
+                    'cerrado' => 0,
+                    'activo' => 1,
+                ];
+            }
+        }
+
+        $vars = parent::buildFormVariables($item);
+        if ($item && empty($item['id'])) {
+            $vars['isEdit'] = false;
+            $vars['pageTitle'] = "Nuevo {$this->title}";
+        }
+
+        $vars['auditoria_options'] = $this->getRelatedOptions('auditorias', 'nombre');
+        $vars['tipo_options'] = Listado::tipoOptions();
+        $vars['gravedad_options'] = Listado::gravedadOptions();
+        $vars['mejora_options'] = $this->getMejoraOptions();
+
+        $key = strtolower($this->flashPrefix);
+        if (!empty($vars[$key])) {
+            $h = $vars[$key];
+            $h['auditoria_label'] = $this->getRelatedLabel('auditorias', $h['auditoria'] ?? null);
+            $vars[$key] = $h;
+        }
+        return $vars;
+    }
+
+    protected function getMejoraOptions(): array
+    {
+        $db = $this->getDb();
+        $db->consulta('SELECT id, descripcion FROM acciones_mejora ORDER BY id');
+        $opts = [];
+        while ($row = $db->coger_Fila()) {
+            $desc = $row[1] ?? '';
+            if (strlen($desc) > 60) {
+                $desc = substr($desc, 0, 57) . '…';
+            }
+            $opts[] = ['id' => $row[0], 'nombre' => '#' . $row[0] . ' — ' . $desc];
+        }
+        $db->desconexion();
+        return $opts;
+    }
+
+    protected function getPostData(): array
+    {
+        return [
+            'auditoria'     => isset($_POST['auditoria']) && $_POST['auditoria'] !== '' ? (int)$_POST['auditoria'] : null,
+            'fecha'         => trim($_POST['fecha'] ?? ''),
+            'descripcion'   => trim($_POST['descripcion'] ?? ''),
+            'tipo'          => trim($_POST['tipo'] ?? 'observacion'),
+            'gravedad'      => trim($_POST['gravedad'] ?? 'menor'),
+            'cerrado'       => !empty($_POST['cerrado']) ? 1 : 0,
+            'accion_mejora' => isset($_POST['accion_mejora']) && $_POST['accion_mejora'] !== '' ? (int)$_POST['accion_mejora'] : null,
+            'activo'        => !empty($_POST['activo']) ? 1 : 0,
+            'observaciones' => trim($_POST['observaciones'] ?? ''),
+        ];
+    }
+
+    protected function validate(array $data): array
+    {
+        $errors = [];
+        if (($data['descripcion'] ?? '') === '') {
+            $errors[] = 'La descripción del hallazgo es obligatoria.';
+        }
+        if (empty($data['auditoria'])) {
+            $errors[] = 'La auditoría es obligatoria.';
+        }
+        return $errors;
+    }
+
+    protected function persist(array $data, $id)
+    {
+        $db = $this->getDb();
+        $params = [
+            $data['auditoria'],
+            $data['fecha'] ?: null,
+            $data['descripcion'],
+            $data['tipo'] ?: 'observacion',
+            $data['gravedad'] ?: 'menor',
+            $data['cerrado'],
+            $data['accion_mejora'],
+            $data['activo'],
+            $data['observaciones'],
+        ];
+        if ($id > 0) {
+            $params[] = $id;
+            $db->consultaPreparada(
+                "UPDATE {$this->table} SET auditoria = ?, fecha = ?, descripcion = ?, tipo = ?, gravedad = ?, cerrado = ?, accion_mejora = ?, activo = ?, observaciones = ? WHERE id = ?",
+                $params
+            );
+        } else {
+            $db->consultaPreparada(
+                "INSERT INTO {$this->table} (auditoria, fecha, descripcion, tipo, gravedad, cerrado, accion_mejora, activo, observaciones) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                $params
+            );
+        }
+        $db->desconexion();
+    }
+}

--- a/Pages/Auditorias/Hallazgos/Listado.php
+++ b/Pages/Auditorias/Hallazgos/Listado.php
@@ -1,0 +1,134 @@
+<?php
+namespace Tuqan\Pages\Auditorias\Hallazgos;
+use Tuqan\Pages\Catalog\CatalogListado;
+
+class Listado extends CatalogListado
+{
+    protected string $table       = 'hallazgos_auditoria';
+    protected string $title       = 'Hallazgos de Auditoría';
+    protected string $templateDir = 'auditorias/hallazgos';
+    protected string $flashPrefix = 'hallazgo';
+
+    protected function getSelectSql(): string
+    {
+        return "SELECT id, auditoria, fecha, descripcion, tipo, gravedad, cerrado, accion_mejora, activo FROM {$this->table} ORDER BY id";
+    }
+
+    protected function mapRow($row): array
+    {
+        return [
+            'id'            => $row[0],
+            'auditoria'     => $row[1] ?? null,
+            'fecha'         => $row[2] ?? null,
+            'descripcion'   => $row[3],
+            'tipo'          => $row[4] ?? null,
+            'gravedad'      => $row[5] ?? null,
+            'cerrado'       => $row[6],
+            'accion_mejora' => $row[7] ?? null,
+            'activo'        => $row[8],
+        ];
+    }
+
+    protected function fetchItems(): array
+    {
+        $filters = $this->getFilterParams();
+        $sql = "SELECT id, auditoria, fecha, descripcion, tipo, gravedad, cerrado, accion_mejora, activo FROM {$this->table}";
+        $params = [];
+        if ($filters['auditoria'] !== null) {
+            $sql .= ' WHERE auditoria = ?';
+            $params[] = $filters['auditoria'];
+        }
+        $sql .= ' ORDER BY id';
+
+        $db = $this->getDb();
+        if ($params) {
+            $db->consultaPreparada($sql, $params);
+        } else {
+            $db->consulta($sql);
+        }
+        $items = [];
+        while ($row = $db->coger_Fila()) {
+            $items[] = $this->mapRow($row);
+        }
+        $db->desconexion();
+
+        foreach ($items as &$item) {
+            $item['auditoria_label'] = $this->getRelatedLabel('auditorias', $item['auditoria'] ?? null);
+            $item['mejora_label'] = $this->getMejoraLabel($item['accion_mejora'] ?? null);
+            $item['tipo_label'] = self::tipoLabel($item['tipo'] ?? null);
+            $item['gravedad_label'] = self::gravedadLabel($item['gravedad'] ?? null);
+        }
+        unset($item);
+        return $items;
+    }
+
+    protected function getMejoraLabel($id): ?string
+    {
+        if (!$id) {
+            return null;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada('SELECT id, descripcion FROM acciones_mejora WHERE id = ?', [(int)$id]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row) {
+            return null;
+        }
+        $desc = $row[1] ?? '';
+        if (strlen($desc) > 48) {
+            $desc = substr($desc, 0, 45) . '…';
+        }
+        return '#' . $row[0] . ' ' . $desc;
+    }
+
+    public static function tipoLabel($tipo): string
+    {
+        $map = [
+            'no_conformidad' => 'No conformidad',
+            'observacion'    => 'Observación',
+            'oportunidad'    => 'Oportunidad',
+        ];
+        return $map[$tipo ?? ''] ?? ($tipo ?: '—');
+    }
+
+    public static function gravedadLabel($g): string
+    {
+        $map = [
+            'mayor'  => 'Mayor',
+            'menor'  => 'Menor',
+            'leve'   => 'Leve',
+        ];
+        return $map[$g ?? ''] ?? ($g ?: '—');
+    }
+
+    public static function tipoOptions(): array
+    {
+        return [
+            ['id' => 'no_conformidad', 'nombre' => 'No conformidad'],
+            ['id' => 'observacion', 'nombre' => 'Observación'],
+            ['id' => 'oportunidad', 'nombre' => 'Oportunidad'],
+        ];
+    }
+
+    public static function gravedadOptions(): array
+    {
+        return [
+            ['id' => 'mayor', 'nombre' => 'Mayor'],
+            ['id' => 'menor', 'nombre' => 'Menor'],
+            ['id' => 'leve', 'nombre' => 'Leve'],
+        ];
+    }
+
+    protected function buildListVariables(array $items): array
+    {
+        $vars = parent::buildListVariables($items);
+        $vars['hallazgo'] = $items;
+        $filters = $this->getFilterParams();
+        $vars['auditoria_options'] = $this->getRelatedOptions('auditorias', 'nombre');
+        $vars['filter_auditoria'] = $filters['auditoria'];
+        if ($filters['auditoria'] !== null) {
+            $vars['filter_auditoria_label'] = $this->getRelatedLabel('auditorias', $filters['auditoria']);
+        }
+        return $vars;
+    }
+}

--- a/docker/db-init/data-patches/0042-auditorias-hallazgos.sql
+++ b/docker/db-init/data-patches/0042-auditorias-hallazgos.sql
@@ -1,0 +1,32 @@
+-- 0042-auditorias-hallazgos.sql
+-- Stage 9.32: Hallazgos de auditoría (modern first slice; no legacy table in clean schema)
+-- Linked to auditorias ejecución; optional accion_mejora.
+
+CREATE TABLE IF NOT EXISTS hallazgos_auditoria (
+    id SERIAL PRIMARY KEY,
+    auditoria INTEGER,
+    fecha DATE,
+    descripcion TEXT NOT NULL,
+    tipo VARCHAR(32) DEFAULT 'observacion',
+    gravedad VARCHAR(32) DEFAULT 'menor',
+    cerrado BOOLEAN DEFAULT false,
+    accion_mejora INTEGER,
+    activo BOOLEAN DEFAULT true,
+    observaciones TEXT
+);
+
+INSERT INTO hallazgos_auditoria (auditoria, fecha, descripcion, tipo, gravedad, cerrado, accion_mejora, activo)
+SELECT 1, '2025-01-20', 'Falta evidencia de formación en el área de producción', 'no_conformidad', 'mayor', false, 1, true
+WHERE NOT EXISTS (SELECT 1 FROM hallazgos_auditoria WHERE descripcion LIKE 'Falta evidencia de formación%');
+
+INSERT INTO hallazgos_auditoria (auditoria, fecha, descripcion, tipo, gravedad, cerrado, activo)
+SELECT 1, '2025-01-20', 'Mejora recomendada en el control de registros', 'oportunidad', 'menor', false, true
+WHERE NOT EXISTS (SELECT 1 FROM hallazgos_auditoria WHERE descripcion LIKE 'Mejora recomendada en el control%');
+
+INSERT INTO hallazgos_auditoria (auditoria, fecha, descripcion, tipo, gravedad, cerrado, accion_mejora, activo)
+SELECT 2, '2025-02-12', 'Proveedor sin evaluación actualizada en expediente', 'no_conformidad', 'menor', false, 2, true
+WHERE NOT EXISTS (SELECT 1 FROM hallazgos_auditoria WHERE descripcion LIKE 'Proveedor sin evaluación%');
+
+INSERT INTO data_patches (filename, applied_at)
+VALUES ('0042-auditorias-hallazgos.sql', NOW())
+ON CONFLICT (filename) DO NOTHING;

--- a/index.php
+++ b/index.php
@@ -424,6 +424,13 @@ $router->addRoute('GET', '/admin/auditorias/ejecucion/editar/{id}', ['Tuqan\Page
 $router->addRoute('POST', '/admin/auditorias/ejecucion/nuevo', ['Tuqan\Pages\Auditorias\Ejecucion\Formulario', 'Procesar'], ['before' => 'auth_company']);
 $router->addRoute('POST', '/admin/auditorias/ejecucion/editar/{id}', ['Tuqan\Pages\Auditorias\Ejecucion\Formulario', 'Procesar'], ['before' => 'auth_company']);
 
+// === Auditorías Hallazgos (Stage 9.32 first slice) ===
+$router->addRoute('GET', '/admin/auditorias/hallazgos', ['Tuqan\Pages\Auditorias\Hallazgos\Listado', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/auditorias/hallazgos/nuevo', ['Tuqan\Pages\Auditorias\Hallazgos\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/auditorias/hallazgos/editar/{id}', ['Tuqan\Pages\Auditorias\Hallazgos\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/auditorias/hallazgos/nuevo', ['Tuqan\Pages\Auditorias\Hallazgos\Formulario', 'Procesar'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/auditorias/hallazgos/editar/{id}', ['Tuqan\Pages\Auditorias\Hallazgos\Formulario', 'Procesar'], ['before' => 'auth_company']);
+
 // === Aspectos Ambientales (Stage 9.7 basic slice) ===
 $router->addRoute('GET', '/admin/aspectos', ['Tuqan\Pages\Aspectos\Listado', 'ShowPage'], ['before' => 'auth_company']);
 $router->addRoute('GET', '/admin/aspectos/nuevo', ['Tuqan\Pages\Aspectos\Formulario', 'ShowPage'], ['before' => 'auth_company']);

--- a/reference/stage-9.32-auditorias-hallazgos-plan.md
+++ b/reference/stage-9.32-auditorias-hallazgos-plan.md
@@ -1,0 +1,23 @@
+# Stage 9.32 — Auditorías hallazgos first slice
+
+**Status**: Planning (plan first)
+**Branch**: `feat/stage-9.32-auditorias-hallazgos`
+**Driver**: Sized next after 9.31. No legacy `hallazgos` table in clean schema — introduce minimal modern table + list/form linked to `auditorias` ejecución (and optional Mejora).
+
+## Goals
+1. Patch **0042**: `CREATE TABLE hallazgos_auditoria` + demo rows + data_patches.
+2. `Pages/Auditorias/Hallazgos/{Listado,Formulario}` on Catalog base.
+3. Routes `/admin/auditorias/hallazgos` (+ nuevo/editar POST/GET).
+4. Filter by `auditoria`; prefill `?auditoria=`; reverse count on ejecución list; section on ejecución form.
+5. Optional FK display/select for `accion_mejora`.
+6. verify + playbook + TODOS.
+
+## Out
+- Plan/horario, informes PDF, full findings workflow, auto-create Mejora.
+
+## Sizing
+- One outcome: CRUD hallazgos linked to ejecución + navigation.
+- ~12–16 files, 1 patch.
+
+---
+*Plan committed first. Docker-only.*

--- a/scripts/verify-8.6.sh
+++ b/scripts/verify-8.6.sh
@@ -47,7 +47,7 @@ export PGPASSWORD="${DB_PASS:-secret}"
 psql -h "${DB_HOST:-db}" -U qnova -d qnova -v ON_ERROR_STOP=1 -c "
 -- Tables (8.6 + 8.7 + 8.8 + 9.2 + 9.3 + 9.4 + 9.5 + 9.6 + 9.7 + 9.9)
 SELECT tablename FROM pg_tables 
-WHERE schemaname='public' AND tablename IN ('sedes','clientes','criterios','tiposmejora','empresas','tipoaccionesmejora','tiposareas','tipodocumento','tiposamb','tiposimp','tipocursos','proveedores','equipos','acciones_mejora','plan_formacion','documentos','programa_auditoria','aspectos','indicadores','procesos','contenido_procesos','auditorias','cursos','alumnos','contenido_texto')
+WHERE schemaname='public' AND tablename IN ('sedes','clientes','criterios','tiposmejora','empresas','tipoaccionesmejora','tiposareas','tipodocumento','tiposamb','tiposimp','tipocursos','proveedores','equipos','acciones_mejora','plan_formacion','documentos','programa_auditoria','aspectos','indicadores','procesos','contenido_procesos','auditorias','cursos','alumnos','contenido_texto','hallazgos_auditoria')
 ORDER BY tablename;
 
 -- Sedes rename evidence
@@ -123,6 +123,11 @@ SELECT curso, COUNT(*) AS n FROM alumnos WHERE curso IS NOT NULL GROUP BY curso 
 SELECT '0041-documentacion-estados.sql' AS patch, COUNT(*) FROM data_patches WHERE filename = '0041-documentacion-estados.sql';
 SELECT estado, COUNT(*) AS n FROM documentos WHERE estado IS NOT NULL GROUP BY estado ORDER BY estado;
 SELECT COUNT(*) AS documentos_con_estado FROM documentos WHERE estado IS NOT NULL;
+
+-- 9.32 Auditorías hallazgos evidence
+SELECT '0042-auditorias-hallazgos.sql' AS patch, COUNT(*) FROM data_patches WHERE filename = '0042-auditorias-hallazgos.sql';
+SELECT COUNT(*) AS hallazgos_rows FROM hallazgos_auditoria;
+SELECT auditoria, COUNT(*) AS n FROM hallazgos_auditoria GROUP BY auditoria ORDER BY auditoria;
 
 -- 9.5 Formación (Planes) + Documentación evidence
 SELECT COUNT(*) AS plan_formacion_rows FROM plan_formacion;

--- a/templates/auditorias/ejecucion/formulario.twig
+++ b/templates/auditorias/ejecucion/formulario.twig
@@ -116,10 +116,52 @@
                 </div>
             {% endif %}
         </div>
+
+        <div style="margin-top: 28px; padding-top: 16px; border-top: 1px solid #eee;">
+            <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px;">
+                <h4 style="margin:0; font-size:16px;">Hallazgos</h4>
+                <div>
+                    <a href="/admin/auditorias/hallazgos?auditoria={{ auditoria.id }}" class="btn btn-default btn-sm">Ver en listado</a>
+                    <a href="/admin/auditorias/hallazgos/nuevo?auditoria={{ auditoria.id }}" class="btn btn-primary btn-sm">Nuevo hallazgo</a>
+                </div>
+            </div>
+            {% if hallazgos_relacionados is empty %}
+                <div class="alert alert-info" style="margin-bottom:0;">No hay hallazgos registrados para esta auditoría.</div>
+            {% else %}
+                <div class="table-responsive">
+                    <table class="table table-condensed table-striped">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Fecha</th>
+                                <th>Descripción</th>
+                                <th>Tipo</th>
+                                <th>Cerrado</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for h in hallazgos_relacionados %}
+                            <tr>
+                                <td>{{ h.id }}</td>
+                                <td>{{ h.fecha ?? '-' }}</td>
+                                <td>{{ h.descripcion }}</td>
+                                <td>{{ h.tipo ?? '-' }}</td>
+                                <td>{% if h.cerrado %}<span class="label label-success">Sí</span>{% else %}<span class="label label-default">No</span>{% endif %}</td>
+                                <td style="text-align:right;">
+                                    <a href="/admin/auditorias/hallazgos/editar/{{ h.id }}" class="btn btn-xs btn-default">Editar</a>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% endif %}
+        </div>
         {% endif %}
 
         <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
-            Auditorías ejecución (9.19 + 9.29 Mejora cross-links). Plan/horario, hallazgos e informes deferred.
+            Auditorías ejecución (9.19 + 9.29 Mejora + 9.32 Hallazgos). Plan/horario e informes deferred.
         </div>
     </form>
 </div>

--- a/templates/auditorias/ejecucion/listado.twig
+++ b/templates/auditorias/ejecucion/listado.twig
@@ -7,6 +7,7 @@
     <div style="display: flex; justify-content: space-between; align-items: center;">
         <h2 style="margin: 0; font-size: 20px;">Auditorías (Ejecución)</h2>
         <div>
+            <a href="/admin/auditorias/hallazgos" class="btn btn-default btn-sm">Hallazgos</a>
             <a href="/admin/auditorias/ejecucion/nuevo" class="btn btn-primary btn-sm">
                 <span class="glyphicon glyphicon-plus"></span> Nueva Auditoría
             </a>
@@ -29,7 +30,8 @@
                         <th>Estado</th>
                         <th>Activo</th>
                         <th>Mejora</th>
-                        <th style="width:200px;text-align:right;">Acciones</th>
+                        <th>Hallazgos</th>
+                        <th style="width:240px;text-align:right;">Acciones</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -43,13 +45,21 @@
                         <td>{% if a.activo %}<span class="label label-success">Sí</span>{% else %}<span class="label label-default">No</span>{% endif %}</td>
                         <td>
                             {% if a.mejora_count > 0 %}
-                                <a href="/admin/mejora?auditoria={{ a.id }}">{{ a.mejora_count }} acción{{ a.mejora_count != 1 ? 'es' : '' }}</a>
+                                <a href="/admin/mejora?auditoria={{ a.id }}">{{ a.mejora_count }}</a>
+                            {% else %}
+                                <span class="text-muted">0</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if a.hallazgo_count > 0 %}
+                                <a href="/admin/auditorias/hallazgos?auditoria={{ a.id }}">{{ a.hallazgo_count }}</a>
                             {% else %}
                                 <span class="text-muted">0</span>
                             {% endif %}
                         </td>
                         <td style="text-align:right; white-space: nowrap;">
                             <a href="/admin/auditorias/ejecucion/editar/{{ a.id }}" class="btn btn-xs btn-default">Editar</a>
+                            <a href="/admin/auditorias/hallazgos/nuevo?auditoria={{ a.id }}" class="btn btn-xs btn-info" title="Nuevo hallazgo">+ Hallazgo</a>
                             <a href="/admin/mejora/nuevo?auditoria={{ a.id }}" class="btn btn-xs btn-primary" title="Crear acción de mejora ligada">+ Mejora</a>
                         </td>
                     </tr>
@@ -59,7 +69,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Auditorías ejecución (9.19 + 9.29 cross-links Mejora). Plan/horario, hallazgos e informes deferred.
+        Auditorías ejecución (9.19 + 9.29 Mejora + 9.32 Hallazgos). Plan/horario e informes deferred.
     </div>
 </div>
 {% endblock %}

--- a/templates/auditorias/hallazgos/formulario.twig
+++ b/templates/auditorias/hallazgos/formulario.twig
@@ -1,0 +1,119 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}{{ pageTitle }} - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <h2 style="margin: 0; font-size: 20px;">{{ pageTitle }}</h2>
+        <div>
+            <a href="/admin/auditorias/hallazgos" class="btn btn-default btn-sm">Volver al listado</a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px; max-width: 780px;">
+    <form method="POST" action="{{ isEdit ? '/admin/auditorias/hallazgos/editar/' ~ hallazgo.id : '/admin/auditorias/hallazgos/nuevo' }}">
+        {% if isEdit %}
+            <input type="hidden" name="id" value="{{ hallazgo.id }}">
+        {% endif %}
+
+        <div class="form-group">
+            <label for="auditoria">Auditoría</label>
+            <select class="form-control" id="auditoria" name="auditoria" required>
+                <option value="">-- Seleccionar --</option>
+                {% for a in auditoria_options %}
+                    <option value="{{ a.id }}" {% if a.id == hallazgo.auditoria %}selected{% endif %}>{{ a.nombre }}</option>
+                {% endfor %}
+            </select>
+            {% if hallazgo.auditoria %}
+                <p class="help-block" style="margin-top:6px;">
+                    <a href="/admin/auditorias/ejecucion/editar/{{ hallazgo.auditoria }}">Ver auditoría</a>
+                    ·
+                    <a href="/admin/auditorias/hallazgos?auditoria={{ hallazgo.auditoria }}">Otros hallazgos</a>
+                </p>
+            {% endif %}
+        </div>
+
+        <div class="form-group">
+            <label for="fecha">Fecha</label>
+            <input type="date" class="form-control" id="fecha" name="fecha" value="{{ hallazgo.fecha ?? '' }}">
+        </div>
+
+        <div class="form-group">
+            <label for="descripcion">Descripción</label>
+            <textarea class="form-control" id="descripcion" name="descripcion" rows="3" required>{{ hallazgo.descripcion ?? '' }}</textarea>
+        </div>
+
+        <div class="row">
+            <div class="col-md-6">
+                <div class="form-group">
+                    <label for="tipo">Tipo</label>
+                    <select class="form-control" id="tipo" name="tipo">
+                        {% for t in tipo_options %}
+                            <option value="{{ t.id }}" {% if t.id == hallazgo.tipo %}selected{% endif %}>{{ t.nombre }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="form-group">
+                    <label for="gravedad">Gravedad</label>
+                    <select class="form-control" id="gravedad" name="gravedad">
+                        {% for g in gravedad_options %}
+                            <option value="{{ g.id }}" {% if g.id == hallazgo.gravedad %}selected{% endif %}>{{ g.nombre }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label for="accion_mejora">Acción de mejora vinculada</label>
+            <select class="form-control" id="accion_mejora" name="accion_mejora">
+                <option value="">-- Ninguna --</option>
+                {% for m in mejora_options %}
+                    <option value="{{ m.id }}" {% if m.id == hallazgo.accion_mejora %}selected{% endif %}>{{ m.nombre }}</option>
+                {% endfor %}
+            </select>
+            {% if hallazgo.accion_mejora %}
+                <p class="help-block"><a href="/admin/mejora/editar/{{ hallazgo.accion_mejora }}">Abrir acción de mejora</a></p>
+            {% endif %}
+        </div>
+
+        <div class="form-group">
+            <label for="observaciones">Observaciones</label>
+            <textarea class="form-control" id="observaciones" name="observaciones" rows="2">{{ hallazgo.observaciones ?? '' }}</textarea>
+        </div>
+
+        <div class="form-group">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="cerrado" value="1" {% if hallazgo.cerrado %}checked{% endif %}>
+                    Cerrado
+                </label>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="activo" value="1" {% if not isEdit or hallazgo.activo %}checked{% endif %}>
+                    Activo
+                </label>
+            </div>
+        </div>
+
+        <div class="form-group" style="margin-top: 20px;">
+            <button type="submit" class="btn btn-primary">
+                {{ isEdit ? 'Guardar cambios' : 'Crear Hallazgo' }}
+            </button>
+            <a href="/admin/auditorias/hallazgos" class="btn btn-default" style="margin-left: 8px;">Cancelar</a>
+        </div>
+
+        <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
+            Hallazgos de auditoría (Stage 9.32). Tabla moderna + enlace a ejecución y Mejora.
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/templates/auditorias/hallazgos/listado.twig
+++ b/templates/auditorias/hallazgos/listado.twig
@@ -1,0 +1,85 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}Hallazgos de Auditoría - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <h2 style="margin: 0; font-size: 20px;">Hallazgos de Auditoría</h2>
+        <div>
+            <a href="/admin/auditorias/ejecucion" class="btn btn-default btn-sm">Ejecución</a>
+            <a href="/admin/auditorias/hallazgos/nuevo{% if filter_auditoria %}?auditoria={{ filter_auditoria }}{% endif %}" class="btn btn-primary btn-sm">
+                <span class="glyphicon glyphicon-plus"></span> Nuevo Hallazgo
+            </a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px;">
+    <form method="GET" action="/admin/auditorias/hallazgos" class="form-inline" style="margin-bottom: 15px;">
+        <div class="form-group" style="margin-right: 8px;">
+            <label for="auditoria" style="margin-right: 6px;">Auditoría</label>
+            <select class="form-control input-sm" id="auditoria" name="auditoria">
+                <option value="">-- Todas --</option>
+                {% for a in auditoria_options %}
+                    <option value="{{ a.id }}" {% if filter_auditoria == a.id %}selected{% endif %}>{{ a.nombre }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button type="submit" class="btn btn-default btn-sm">Filtrar</button>
+        {% if filter_auditoria %}
+            <a href="/admin/auditorias/hallazgos" class="btn btn-link btn-sm">Quitar filtro</a>
+        {% endif %}
+    </form>
+
+    {% if hallazgo is empty %}
+        <div class="alert alert-info">No hay hallazgos registrados{% if filter_auditoria %} para esta auditoría{% endif %}.</div>
+    {% else %}
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Fecha</th>
+                        <th>Descripción</th>
+                        <th>Auditoría</th>
+                        <th>Tipo</th>
+                        <th>Gravedad</th>
+                        <th>Mejora</th>
+                        <th>Cerrado</th>
+                        <th style="width:100px;text-align:right;">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for h in hallazgo %}
+                    <tr>
+                        <td>{{ h.id }}</td>
+                        <td>{{ h.fecha ?? '-' }}</td>
+                        <td><strong>{{ h.descripcion }}</strong></td>
+                        <td>
+                            {% if h.auditoria %}
+                                <a href="/admin/auditorias/ejecucion/editar/{{ h.auditoria }}">{{ h.auditoria_label ?? h.auditoria }}</a>
+                            {% else %}-{% endif %}
+                        </td>
+                        <td>{{ h.tipo_label ?? h.tipo ?? '-' }}</td>
+                        <td>{{ h.gravedad_label ?? h.gravedad ?? '-' }}</td>
+                        <td>
+                            {% if h.accion_mejora %}
+                                <a href="/admin/mejora/editar/{{ h.accion_mejora }}">{{ h.mejora_label ?? h.accion_mejora }}</a>
+                            {% else %}-{% endif %}
+                        </td>
+                        <td>{% if h.cerrado %}<span class="label label-success">Sí</span>{% else %}<span class="label label-default">No</span>{% endif %}</td>
+                        <td style="text-align:right;">
+                            <a href="/admin/auditorias/hallazgos/editar/{{ h.id }}" class="btn btn-xs btn-default">Editar</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+    <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
+        Hallazgos (Stage 9.32 first slice). Plan/horario e informes deferred.
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Stage 9.32 — Auditorías hallazgos first slice

No legacy hallazgos table in the clean schema — introduces a minimal modern table and Catalog list/form, wired into ejecución (same cross-link pattern as Mejora 9.29).

### Delivered
- **Table** `hallazgos_auditoria` (auditoria, fecha, descripcion, tipo, gravedad, cerrado, accion_mejora, activo, observaciones)
- **CRUD** `/admin/auditorias/hallazgos` (+ nuevo/editar)
- Filter by auditoría; prefill `?auditoria=`
- Optional link to **acciones_mejora**
- **Ejecución**: hallazgo counts, + Hallazgo button, related hallazgos on edit form
- Patch **0042**, verify asserts, living docs

### Out of scope
Plan/horario, informes PDF, auto-create Mejora from hallazgo.

### Verify
php -l green · 3 demo hallazgos · verify script green

Browser: `/admin/auditorias/hallazgos`, filter, create from ejecución, open Mejora link.

Plan committed first. Docker-only.