### PR TITLE
feat(9.33): Equipos revisiones shell (mantenimientos)

### DIFF
--- a/.agents/MIGRATION-TODOS.md
+++ b/.agents/MIGRATION-TODOS.md
@@ -5,7 +5,7 @@ MIGRATION-PLAN.md = architecture, constraints, high-level stages + history.
 STAGE-CHECKLISTS.md = detailed per-leg playbooks, exact commands, evidence, retrospective lessons.  
 **This file** = scannable "what is left, how big is it, what should the next PR be?" + handoff package for other agents.
 
-**Last updated**: Stage 9.32 on `feat/stage-9.32-auditorias-hallazgos` (Auditorías hallazgos first slice). Previous: 9.31 Documentación estado.
+**Last updated**: Stage 9.33 on `feat/stage-9.33-equipos-revisiones` (Equipos revisiones / mantenimientos). Previous: 9.32 Auditorías hallazgos.
 
 ---
 
@@ -101,10 +101,11 @@ Pick 1-2 related items that together form a reviewable PR. Update this list when
 - [x] **Formación cross-links hub**: Delivered in Stage 9.30 (Planes curso counts, Cursos filter by plan + inscripción counts, Inscripciones filter by curso, prefills, nested list key fix, nav between subs). See 9.30 plan and STAGE-CHECKLISTS.
 - [x] **Documentación estado/filter polish**: Delivered in Stage 9.31 (estado labels/badges from legacy codes, list filter estado+activo, form select + badge, EstadoHelper, patch 0041). See 9.31 plan and STAGE-CHECKLISTS.
 - [x] **Auditorías hallazgos first slice**: Delivered in Stage 9.32 (`hallazgos_auditoria` table, list/form, filter by auditoría, reverse links on ejecución, optional Mejora FK, patch 0042). See 9.32 plan and STAGE-CHECKLISTS.
+- [x] **Equipos revisiones shell**: Delivered in Stage 9.33 (`mantenimientos` list/form, filter by equipo, reverse counts, prefill, patch 0043). See 9.33 plan and STAGE-CHECKLISTS.
 - [ ] **Next** (sized picks):  
-  - Equipos revisiones shell · In: list+form revisiones · Out: calendario · ~12 files · patch? yes  
   - Documentación quick workflow actions · In: revisar/aprobar buttons like Mejora · Out: rich editor · ~12 files · patch? small  
-  - Auditorías plan/horario · In: horario_auditoria shell · Out: informes · ~12 files · patch? yes
+  - Auditorías plan/horario · In: horario_auditoria shell · Out: informes · ~12 files · patch? yes  
+  - Equipos calendario / plan mantenimiento · In: calendar view shell · Out: full preventivo workflows · ~15 files · patch? maybe
 
 Aim for a mix: one "close the small gaps" + one "new vertical" per couple of legs. Keep delivering working, reviewable increments.
 
@@ -137,8 +138,8 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 - [ ] Homologacion / evaluation flows (common in ISO supplier management).
 
 ### Equipos (Equipment / Assets)
-- [x] Equipos (legacy 70) — basic listado + form (core fields: numero, descripcion, modelo, ubicacion, activo + supporting) in Stage 9.3. Followed catalog base + full routes (corrected pattern) + data patch 0021 + verify + playbook. Sub-flows (revisiones, calendario, plan mantenimiento, etc.) deferred to later legs. (See 9.3 plan and STAGE-CHECKLISTS.)
-- [ ] Revisiones + compliance records + maintenance workflows (tie to Auditorias / Mejora).
+- [x] Equipos (legacy 70) — basic listado + form (core fields: numero, descripcion, modelo, ubicacion, activo + supporting) in Stage 9.3. Revisiones shell (`mantenimientos` CRUD + links) in Stage 9.33. Calendario y plan mantenimiento deferred. (See 9.3 + 9.33 plans.)
+- [ ] Calendario + plan mantenimiento / deeper maintenance workflows (tie to Auditorias / Mejora).
 
 ### Documentación (Core ISO — high value, likely larger)
 - [x] Documentación initial shell delivered in Stage 9.5. Tree in 9.12. Editor/perfiles in 9.23, workflows in 9.24, content editor (texto) in 9.26. Estado labels + list filter in 9.31. Full rich editor, binario, more, PDF deferred. See 9.5 + 9.12 + 9.23 + 9.24 + 9.26 + 9.31 plans.

--- a/.agents/STAGE-CHECKLISTS.md
+++ b/.agents/STAGE-CHECKLISTS.md
@@ -3580,6 +3580,23 @@ docker compose exec db psql -U qnova -d qnova -c "SELECT COUNT(*) FROM hallazgos
 **Branch status:** Stage 9.32 on `feat/stage-9.32-auditorias-hallazgos`.
 
 
+## Stage 9.33 — Equipos revisiones shell (mantenimientos)
+
+**Goal:** Modern list/form for equipo revisiones using legacy `mantenimientos` table; filter/prefill by equipo; reverse counts on equipos list.
+
+**Validation:**
+```bash
+docker compose exec app ./scripts/init-db.sh
+docker compose exec app php -l Pages/Equipos/Listado.php Pages/Equipos/Revisiones/Listado.php Pages/Equipos/Revisiones/Formulario.php index.php
+docker compose exec app ./scripts/verify-8.6.sh
+docker compose exec db psql -U qnova -d qnova -c "SELECT COUNT(*) FROM mantenimientos; SELECT equipo, COUNT(*) FROM mantenimientos GROUP BY 1;"
+```
+
+**Browser:** /admin/equipos — revisiones counts + + Revisión; /admin/equipos/revisiones filter; create/edit; legacy path /administracion/equipos/revision/listado/ver.
+
+**Branch status:** Stage 9.33 on `feat/stage-9.33-equipos-revisiones`.
+
+
 
 
 

--- a/Pages/Catalog/CatalogListado.php
+++ b/Pages/Catalog/CatalogListado.php
@@ -223,6 +223,8 @@ abstract class CatalogListado
             'curso'     => (isset($_GET['curso']) && $_GET['curso'] !== '') ? (int)$_GET['curso'] : null,
             // 9.31: generic integer estado filter (Documentación, etc.)
             'estado'    => (isset($_GET['estado']) && $_GET['estado'] !== '') ? (int)$_GET['estado'] : null,
+            // 9.33: Equipos revisiones filter
+            'equipo'    => (isset($_GET['equipo']) && $_GET['equipo'] !== '') ? (int)$_GET['equipo'] : null,
         ];
     }
 

--- a/Pages/Equipos/Listado.php
+++ b/Pages/Equipos/Listado.php
@@ -11,7 +11,6 @@ class Listado extends CatalogListado
     protected string $templateDir = 'equipos';
     protected string $flashPrefix = 'equipo';
 
-    // Override because the entity uses 'numero' + 'descripcion' (no 'nombre') and several extra columns.
     protected function getSelectSql(): string
     {
         return "SELECT id, numero, descripcion, modelo, ubicacion, activo FROM {$this->table} ORDER BY id";
@@ -27,5 +26,32 @@ class Listado extends CatalogListado
             'ubicacion'   => $row[4] ?? null,
             'activo'      => $row[5],
         ];
+    }
+
+    // 9.33: reverse count of revisiones (mantenimientos)
+    protected function fetchItems(): array
+    {
+        $items = parent::fetchItems();
+        foreach ($items as &$item) {
+            $item['revision_count'] = $this->countRevisionesForEquipo((int)$item['id']);
+        }
+        unset($item);
+        return $items;
+    }
+
+    protected function countRevisionesForEquipo(int $equipoId): int
+    {
+        if ($equipoId <= 0) {
+            return 0;
+        }
+        try {
+            $db = $this->getDb();
+            $db->consultaPreparada('SELECT COUNT(*) FROM mantenimientos WHERE equipo = ?', [$equipoId]);
+            $row = $db->coger_Fila();
+            $db->desconexion();
+            return (int)($row[0] ?? 0);
+        } catch (\Throwable $e) {
+            return 0;
+        }
     }
 }

--- a/Pages/Equipos/Revisiones/Formulario.php
+++ b/Pages/Equipos/Revisiones/Formulario.php
@@ -1,0 +1,152 @@
+<?php
+namespace Tuqan\Pages\Equipos\Revisiones;
+use Tuqan\Pages\Catalog\CatalogFormulario;
+
+class Formulario extends CatalogFormulario
+{
+    protected string $table        = 'mantenimientos';
+    protected string $title        = 'Revisión de Equipo';
+    protected string $templateDir  = 'equipos/revisiones';
+    protected string $flashPrefix  = 'revision';
+    protected string $listRoute    = '/admin/equipos/revisiones';
+
+    protected function getSelectForForm(): string
+    {
+        return "SELECT id, equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos FROM {$this->table} WHERE id = ?";
+    }
+
+    protected function loadItem($id): ?array
+    {
+        if ($id <= 0) {
+            return null;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada($this->getSelectForForm(), [$id]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row) {
+            return null;
+        }
+        return [
+            'id'             => $row[0],
+            'equipo'         => $row[1] ?? null,
+            'tipo'           => $row[2] ?? 'revision',
+            'fecha_prevista' => $row[3] ?? null,
+            'fecha_realiza'  => $row[4] ?? null,
+            'comentarios'    => $row[5] ?? '',
+            'motivos'        => $row[6] ?? '',
+        ];
+    }
+
+    protected function buildFormVariables(?array $item): array
+    {
+        if ($item === null) {
+            $prefill = (isset($_GET['equipo']) && $_GET['equipo'] !== '') ? (int)$_GET['equipo'] : null;
+            if ($prefill) {
+                $item = [
+                    'id' => null,
+                    'equipo' => $prefill,
+                    'tipo' => 'revision',
+                    'fecha_realiza' => date('Y-m-d'),
+                ];
+            }
+        }
+
+        $vars = parent::buildFormVariables($item);
+        if ($item && empty($item['id'])) {
+            $vars['isEdit'] = false;
+            $vars['pageTitle'] = "Nueva {$this->title}";
+        }
+
+        $vars['equipo_options'] = $this->getEquipoOptions();
+        $vars['tipo_options'] = Listado::tipoOptions();
+
+        $key = strtolower($this->flashPrefix);
+        if (!empty($vars[$key])) {
+            $r = $vars[$key];
+            $r['equipo_label'] = $this->getEquipoLabel($r['equipo'] ?? null);
+            $vars[$key] = $r;
+        }
+        return $vars;
+    }
+
+    protected function getEquipoOptions(): array
+    {
+        $db = $this->getDb();
+        $db->consulta('SELECT id, numero, descripcion FROM equipos ORDER BY numero');
+        $opts = [];
+        while ($row = $db->coger_Fila()) {
+            $opts[] = ['id' => $row[0], 'nombre' => $row[1] . ' — ' . $row[2]];
+        }
+        $db->desconexion();
+        return $opts;
+    }
+
+    protected function getEquipoLabel($id): ?string
+    {
+        if (!$id) {
+            return null;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada('SELECT numero, descripcion FROM equipos WHERE id = ?', [(int)$id]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row) {
+            return null;
+        }
+        return $row[0] . ' — ' . $row[1];
+    }
+
+    protected function getPostData(): array
+    {
+        return [
+            'equipo'         => isset($_POST['equipo']) && $_POST['equipo'] !== '' ? (int)$_POST['equipo'] : null,
+            'tipo'           => trim($_POST['tipo'] ?? 'revision'),
+            'fecha_prevista' => trim($_POST['fecha_prevista'] ?? ''),
+            'fecha_realiza'  => trim($_POST['fecha_realiza'] ?? ''),
+            'comentarios'    => trim($_POST['comentarios'] ?? ''),
+            'motivos'        => trim($_POST['motivos'] ?? ''),
+        ];
+    }
+
+    protected function validate(array $data): array
+    {
+        $errors = [];
+        if (empty($data['equipo'])) {
+            $errors[] = 'El equipo es obligatorio.';
+        }
+        if (($data['fecha_realiza'] ?? '') === '') {
+            $errors[] = 'La fecha de realización es obligatoria.';
+        }
+        if (($data['comentarios'] ?? '') === '') {
+            $errors[] = 'Los comentarios son obligatorios.';
+        }
+        return $errors;
+    }
+
+    protected function persist(array $data, $id)
+    {
+        $db = $this->getDb();
+        $params = [
+            $data['equipo'],
+            $data['tipo'] ?: 'revision',
+            $data['fecha_prevista'] ?: null,
+            $data['fecha_realiza'] ?: date('Y-m-d'),
+            $data['comentarios'] !== '' ? $data['comentarios'] : '-',
+            $data['motivos'] !== '' ? $data['motivos'] : '-',
+        ];
+        if ($id > 0) {
+            $params[] = $id;
+            $db->consultaPreparada(
+                "UPDATE {$this->table} SET equipo = ?, tipo = ?, fecha_prevista = ?, fecha_realiza = ?, comentarios = ?, motivos = ? WHERE id = ?",
+                $params
+            );
+        } else {
+            $db->consultaPreparada(
+                "INSERT INTO {$this->table} (equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos) VALUES (?, ?, ?, ?, ?, ?)",
+                $params
+            );
+        }
+        $db->desconexion();
+    }
+}

--- a/Pages/Equipos/Revisiones/Listado.php
+++ b/Pages/Equipos/Revisiones/Listado.php
@@ -1,0 +1,119 @@
+<?php
+namespace Tuqan\Pages\Equipos\Revisiones;
+use Tuqan\Pages\Catalog\CatalogListado;
+
+class Listado extends CatalogListado
+{
+    protected string $table       = 'mantenimientos';
+    protected string $title       = 'Revisiones de Equipos';
+    protected string $templateDir = 'equipos/revisiones';
+    protected string $flashPrefix = 'revision';
+
+    protected function getSelectSql(): string
+    {
+        return "SELECT id, equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos FROM {$this->table} ORDER BY id";
+    }
+
+    protected function mapRow($row): array
+    {
+        return [
+            'id'             => $row[0],
+            'equipo'         => $row[1] ?? null,
+            'tipo'           => $row[2] ?? null,
+            'fecha_prevista' => $row[3] ?? null,
+            'fecha_realiza'  => $row[4] ?? null,
+            'comentarios'    => $row[5] ?? '',
+            'motivos'        => $row[6] ?? '',
+        ];
+    }
+
+    protected function fetchItems(): array
+    {
+        $filters = $this->getFilterParams();
+        $sql = "SELECT id, equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos FROM {$this->table}";
+        $params = [];
+        if ($filters['equipo'] !== null) {
+            $sql .= ' WHERE equipo = ?';
+            $params[] = $filters['equipo'];
+        }
+        $sql .= ' ORDER BY id DESC';
+
+        $db = $this->getDb();
+        if ($params) {
+            $db->consultaPreparada($sql, $params);
+        } else {
+            $db->consulta($sql);
+        }
+        $items = [];
+        while ($row = $db->coger_Fila()) {
+            $items[] = $this->mapRow($row);
+        }
+        $db->desconexion();
+
+        foreach ($items as &$item) {
+            $item['equipo_label'] = $this->getEquipoLabel($item['equipo'] ?? null);
+            $item['tipo_label'] = self::tipoLabel($item['tipo'] ?? null);
+        }
+        unset($item);
+        return $items;
+    }
+
+    protected function getEquipoLabel($id): ?string
+    {
+        if (!$id) {
+            return null;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada('SELECT id, numero, descripcion FROM equipos WHERE id = ?', [(int)$id]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row) {
+            return null;
+        }
+        return $row[1] . ' — ' . $row[2];
+    }
+
+    public static function tipoLabel($tipo): string
+    {
+        $map = [
+            'revision'   => 'Revisión',
+            'preventivo' => 'Preventivo',
+            'correctivo' => 'Correctivo',
+        ];
+        return $map[$tipo ?? ''] ?? ($tipo ?: '—');
+    }
+
+    public static function tipoOptions(): array
+    {
+        return [
+            ['id' => 'revision', 'nombre' => 'Revisión'],
+            ['id' => 'preventivo', 'nombre' => 'Preventivo'],
+            ['id' => 'correctivo', 'nombre' => 'Correctivo'],
+        ];
+    }
+
+    protected function buildListVariables(array $items): array
+    {
+        $vars = parent::buildListVariables($items);
+        $vars['revision'] = $items;
+        $filters = $this->getFilterParams();
+        $vars['equipo_options'] = $this->getEquipoOptions();
+        $vars['filter_equipo'] = $filters['equipo'];
+        if ($filters['equipo'] !== null) {
+            $vars['filter_equipo_label'] = $this->getEquipoLabel($filters['equipo']);
+        }
+        return $vars;
+    }
+
+    protected function getEquipoOptions(): array
+    {
+        $db = $this->getDb();
+        $db->consulta('SELECT id, numero, descripcion FROM equipos ORDER BY numero');
+        $opts = [];
+        while ($row = $db->coger_Fila()) {
+            $opts[] = ['id' => $row[0], 'nombre' => $row[1] . ' — ' . $row[2]];
+        }
+        $db->desconexion();
+        return $opts;
+    }
+}

--- a/docker/db-init/data-patches/0043-equipos-revisiones.sql
+++ b/docker/db-init/data-patches/0043-equipos-revisiones.sql
@@ -1,0 +1,35 @@
+-- 0043-equipos-revisiones.sql
+-- Stage 9.33: Equipos revisiones / mantenimientos records (legacy table name)
+-- Menu accion equipos:revision:listado:ver
+
+CREATE TABLE IF NOT EXISTS mantenimientos (
+    id SERIAL PRIMARY KEY,
+    equipo INTEGER,
+    tipo VARCHAR(16),
+    fecha_prevista DATE,
+    fecha_realiza DATE NOT NULL DEFAULT CURRENT_DATE,
+    comentarios TEXT NOT NULL DEFAULT '',
+    motivos TEXT NOT NULL DEFAULT ''
+);
+
+INSERT INTO mantenimientos (equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos)
+SELECT 1, 'revision', '2025-03-01', '2025-03-05', 'Revisión trimestral de seguridad', 'Programa de mantenimiento preventivo'
+WHERE NOT EXISTS (
+    SELECT 1 FROM mantenimientos WHERE equipo = 1 AND comentarios LIKE 'Revisión trimestral%'
+);
+
+INSERT INTO mantenimientos (equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos)
+SELECT 1, 'preventivo', '2025-06-01', '2025-06-02', 'Cambio de filtros y lubricación', 'Cada 90 días'
+WHERE NOT EXISTS (
+    SELECT 1 FROM mantenimientos WHERE equipo = 1 AND comentarios LIKE 'Cambio de filtros%'
+);
+
+INSERT INTO mantenimientos (equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos)
+SELECT 2, 'revision', '2025-04-10', '2025-04-12', 'Inspección de sellos hidráulicos', 'Revisión semestral'
+WHERE NOT EXISTS (
+    SELECT 1 FROM mantenimientos WHERE equipo = 2 AND comentarios LIKE 'Inspección de sellos%'
+);
+
+INSERT INTO data_patches (filename, applied_at)
+VALUES ('0043-equipos-revisiones.sql', NOW())
+ON CONFLICT (filename) DO NOTHING;

--- a/index.php
+++ b/index.php
@@ -340,6 +340,15 @@ $router->addRoute('POST', '/admin/equipos/editar/{id}', ['Tuqan\Pages\Equipos\Fo
 // Legacy routes for Equipos (from full legacy menu accions: equipos:listado:listado:ver + administracion variant)
 $router->addRoute('GET', '/administracion/equipos/listado/ver', ['Tuqan\Pages\Equipos\Listado', 'ShowPage'], ['before' => 'auth_company']);
 
+// === Equipos Revisiones / mantenimientos (Stage 9.33) ===
+$router->addRoute('GET', '/admin/equipos/revisiones', ['Tuqan\Pages\Equipos\Revisiones\Listado', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/equipos/revisiones/nuevo', ['Tuqan\Pages\Equipos\Revisiones\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/equipos/revisiones/editar/{id}', ['Tuqan\Pages\Equipos\Revisiones\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/equipos/revisiones/nuevo', ['Tuqan\Pages\Equipos\Revisiones\Formulario', 'Procesar'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/equipos/revisiones/editar/{id}', ['Tuqan\Pages\Equipos\Revisiones\Formulario', 'Procesar'], ['before' => 'auth_company']);
+// Legacy menu: equipos:revision:listado:ver
+$router->addRoute('GET', '/administracion/equipos/revision/listado/ver', ['Tuqan\Pages\Equipos\Revisiones\Listado', 'ShowPage'], ['before' => 'auth_company']);
+
 // === Mejora / Acciones de Mejora (Stage 9.4) ===
 $router->addRoute('GET', '/admin/mejora', ['Tuqan\Pages\Mejora\Listado', 'ShowPage'], ['before' => 'auth_company']);
 $router->addRoute('GET', '/admin/mejora/nuevo', ['Tuqan\Pages\Mejora\Formulario', 'ShowPage'], ['before' => 'auth_company']);

--- a/reference/stage-9.33-equipos-revisiones-plan.md
+++ b/reference/stage-9.33-equipos-revisiones-plan.md
@@ -1,0 +1,22 @@
+# Stage 9.33 — Equipos revisiones shell (mantenimientos)
+
+**Status**: Planning (plan first)
+**Branch**: `feat/stage-9.33-equipos-revisiones`
+**Driver**: Sized next after 9.32. Legacy menu `equipos:revision:listado:ver`; schema has `mantenimientos` (equipo FK) for revision/maintenance records.
+
+## Goals
+1. Patch **0043**: CREATE `mantenimientos` if missing + demo rows linked to equipos.
+2. `Pages/Equipos/Revisiones/{Listado,Formulario}` (table `mantenimientos`).
+3. Routes `/admin/equipos/revisiones` + nuevo/editar; legacy path optional.
+4. Filter by equipo; prefill `?equipo=`; reverse count + **+ Revisión** on equipos list.
+5. verify + playbook + TODOS.
+
+## Out
+- Calendario anual, plan mantenimiento UI, correctivo workflows deep.
+
+## Sizing
+- One outcome: list/edit revisiones per equipo.
+- ~12–15 files, 1 patch.
+
+---
+*Plan committed first. Docker-only.*

--- a/scripts/verify-8.6.sh
+++ b/scripts/verify-8.6.sh
@@ -47,7 +47,7 @@ export PGPASSWORD="${DB_PASS:-secret}"
 psql -h "${DB_HOST:-db}" -U qnova -d qnova -v ON_ERROR_STOP=1 -c "
 -- Tables (8.6 + 8.7 + 8.8 + 9.2 + 9.3 + 9.4 + 9.5 + 9.6 + 9.7 + 9.9)
 SELECT tablename FROM pg_tables 
-WHERE schemaname='public' AND tablename IN ('sedes','clientes','criterios','tiposmejora','empresas','tipoaccionesmejora','tiposareas','tipodocumento','tiposamb','tiposimp','tipocursos','proveedores','equipos','acciones_mejora','plan_formacion','documentos','programa_auditoria','aspectos','indicadores','procesos','contenido_procesos','auditorias','cursos','alumnos','contenido_texto','hallazgos_auditoria')
+WHERE schemaname='public' AND tablename IN ('sedes','clientes','criterios','tiposmejora','empresas','tipoaccionesmejora','tiposareas','tipodocumento','tiposamb','tiposimp','tipocursos','proveedores','equipos','acciones_mejora','plan_formacion','documentos','programa_auditoria','aspectos','indicadores','procesos','contenido_procesos','auditorias','cursos','alumnos','contenido_texto','hallazgos_auditoria','mantenimientos')
 ORDER BY tablename;
 
 -- Sedes rename evidence
@@ -128,6 +128,11 @@ SELECT COUNT(*) AS documentos_con_estado FROM documentos WHERE estado IS NOT NUL
 SELECT '0042-auditorias-hallazgos.sql' AS patch, COUNT(*) FROM data_patches WHERE filename = '0042-auditorias-hallazgos.sql';
 SELECT COUNT(*) AS hallazgos_rows FROM hallazgos_auditoria;
 SELECT auditoria, COUNT(*) AS n FROM hallazgos_auditoria GROUP BY auditoria ORDER BY auditoria;
+
+-- 9.33 Equipos revisiones (mantenimientos) evidence
+SELECT '0043-equipos-revisiones.sql' AS patch, COUNT(*) FROM data_patches WHERE filename = '0043-equipos-revisiones.sql';
+SELECT COUNT(*) AS mantenimientos_rows FROM mantenimientos;
+SELECT equipo, COUNT(*) AS n FROM mantenimientos GROUP BY equipo ORDER BY equipo;
 
 -- 9.5 Formación (Planes) + Documentación evidence
 SELECT COUNT(*) AS plan_formacion_rows FROM plan_formacion;

--- a/templates/equipos/listado.twig
+++ b/templates/equipos/listado.twig
@@ -7,6 +7,7 @@
     <div style="display: flex; justify-content: space-between; align-items: center;">
         <h2 style="margin: 0; font-size: 20px;">Equipos</h2>
         <div>
+            <a href="/admin/equipos/revisiones" class="btn btn-default btn-sm">Revisiones</a>
             <a href="/admin/equipos/nuevo" class="btn btn-primary btn-sm">
                 <span class="glyphicon glyphicon-plus"></span> Nuevo Equipo
             </a>
@@ -21,7 +22,16 @@
         <div class="table-responsive">
             <table class="table table-striped table-hover">
                 <thead>
-                    <tr><th>ID</th><th>Número</th><th>Descripción</th><th>Modelo</th><th>Ubicación</th><th>Estado</th><th style="width:140px;text-align:right;">Acciones</th></tr>
+                    <tr>
+                        <th>ID</th>
+                        <th>Número</th>
+                        <th>Descripción</th>
+                        <th>Modelo</th>
+                        <th>Ubicación</th>
+                        <th>Revisiones</th>
+                        <th>Estado</th>
+                        <th style="width:200px;text-align:right;">Acciones</th>
+                    </tr>
                 </thead>
                 <tbody>
                     {% for e in equipos %}
@@ -31,9 +41,17 @@
                         <td>{{ e.descripcion }}</td>
                         <td>{{ e.modelo ?? '-' }}</td>
                         <td>{{ e.ubicacion ?? '-' }}</td>
+                        <td>
+                            {% if e.revision_count > 0 %}
+                                <a href="/admin/equipos/revisiones?equipo={{ e.id }}">{{ e.revision_count }}</a>
+                            {% else %}
+                                <span class="text-muted">0</span>
+                            {% endif %}
+                        </td>
                         <td>{% if e.activo %}<span class="label label-success">Activo</span>{% else %}<span class="label label-default">Inactivo</span>{% endif %}</td>
-                        <td style="text-align:right;">
+                        <td style="text-align:right; white-space: nowrap;">
                             <a href="/admin/equipos/editar/{{ e.id }}" class="btn btn-xs btn-default">Editar</a>
+                            <a href="/admin/equipos/revisiones/nuevo?equipo={{ e.id }}" class="btn btn-xs btn-primary" title="Nueva revisión">+ Revisión</a>
                         </td>
                     </tr>
                     {% endfor %}
@@ -42,7 +60,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Equipos (Stage 9.3). Revisiones, calendario y planes de mantenimiento se gestionarán en seguimientos posteriores.
+        Equipos (9.3 + 9.33 revisiones). Calendario y plan de mantenimiento deferred.
     </div>
 </div>
 {% endblock %}

--- a/templates/equipos/revisiones/formulario.twig
+++ b/templates/equipos/revisiones/formulario.twig
@@ -1,0 +1,86 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}{{ pageTitle }} - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <h2 style="margin: 0; font-size: 20px;">{{ pageTitle }}</h2>
+        <div>
+            <a href="/admin/equipos/revisiones" class="btn btn-default btn-sm">Volver al listado</a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px; max-width: 780px;">
+    <form method="POST" action="{{ isEdit ? '/admin/equipos/revisiones/editar/' ~ revision.id : '/admin/equipos/revisiones/nuevo' }}">
+        {% if isEdit %}
+            <input type="hidden" name="id" value="{{ revision.id }}">
+        {% endif %}
+
+        <div class="form-group">
+            <label for="equipo">Equipo</label>
+            <select class="form-control" id="equipo" name="equipo" required>
+                <option value="">-- Seleccionar --</option>
+                {% for e in equipo_options %}
+                    <option value="{{ e.id }}" {% if e.id == revision.equipo %}selected{% endif %}>{{ e.nombre }}</option>
+                {% endfor %}
+            </select>
+            {% if revision.equipo %}
+                <p class="help-block" style="margin-top:6px;">
+                    <a href="/admin/equipos/editar/{{ revision.equipo }}">Ver equipo</a>
+                    ·
+                    <a href="/admin/equipos/revisiones?equipo={{ revision.equipo }}">Otras revisiones</a>
+                </p>
+            {% endif %}
+        </div>
+
+        <div class="form-group">
+            <label for="tipo">Tipo</label>
+            <select class="form-control" id="tipo" name="tipo">
+                {% for t in tipo_options %}
+                    <option value="{{ t.id }}" {% if t.id == revision.tipo %}selected{% endif %}>{{ t.nombre }}</option>
+                {% endfor %}
+            </select>
+        </div>
+
+        <div class="row">
+            <div class="col-md-6">
+                <div class="form-group">
+                    <label for="fecha_prevista">Fecha prevista</label>
+                    <input type="date" class="form-control" id="fecha_prevista" name="fecha_prevista"
+                           value="{{ revision.fecha_prevista ?? '' }}">
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="form-group">
+                    <label for="fecha_realiza">Fecha realización</label>
+                    <input type="date" class="form-control" id="fecha_realiza" name="fecha_realiza"
+                           value="{{ revision.fecha_realiza ?? '' }}" required>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label for="comentarios">Comentarios</label>
+            <textarea class="form-control" id="comentarios" name="comentarios" rows="3" required>{{ revision.comentarios ?? '' }}</textarea>
+        </div>
+
+        <div class="form-group">
+            <label for="motivos">Motivos</label>
+            <textarea class="form-control" id="motivos" name="motivos" rows="2">{{ revision.motivos ?? '' }}</textarea>
+        </div>
+
+        <div class="form-group" style="margin-top: 20px;">
+            <button type="submit" class="btn btn-primary">
+                {{ isEdit ? 'Guardar cambios' : 'Crear Revisión' }}
+            </button>
+            <a href="/admin/equipos/revisiones" class="btn btn-default" style="margin-left: 8px;">Cancelar</a>
+        </div>
+
+        <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
+            Revisiones de equipos (Stage 9.33). Tabla legacy <code>mantenimientos</code>.
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/templates/equipos/revisiones/listado.twig
+++ b/templates/equipos/revisiones/listado.twig
@@ -1,0 +1,77 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}Revisiones de Equipos - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <h2 style="margin: 0; font-size: 20px;">Revisiones de Equipos</h2>
+        <div>
+            <a href="/admin/equipos" class="btn btn-default btn-sm">Equipos</a>
+            <a href="/admin/equipos/revisiones/nuevo{% if filter_equipo %}?equipo={{ filter_equipo }}{% endif %}" class="btn btn-primary btn-sm">
+                <span class="glyphicon glyphicon-plus"></span> Nueva Revisión
+            </a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px;">
+    <form method="GET" action="/admin/equipos/revisiones" class="form-inline" style="margin-bottom: 15px;">
+        <div class="form-group" style="margin-right: 8px;">
+            <label for="equipo" style="margin-right: 6px;">Equipo</label>
+            <select class="form-control input-sm" id="equipo" name="equipo">
+                <option value="">-- Todos --</option>
+                {% for e in equipo_options %}
+                    <option value="{{ e.id }}" {% if filter_equipo == e.id %}selected{% endif %}>{{ e.nombre }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button type="submit" class="btn btn-default btn-sm">Filtrar</button>
+        {% if filter_equipo %}
+            <a href="/admin/equipos/revisiones" class="btn btn-link btn-sm">Quitar filtro</a>
+        {% endif %}
+    </form>
+
+    {% if revision is empty %}
+        <div class="alert alert-info">No hay revisiones registradas{% if filter_equipo %} para este equipo{% endif %}.</div>
+    {% else %}
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Equipo</th>
+                        <th>Tipo</th>
+                        <th>Prevista</th>
+                        <th>Realizada</th>
+                        <th>Comentarios</th>
+                        <th style="width:100px;text-align:right;">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for r in revision %}
+                    <tr>
+                        <td>{{ r.id }}</td>
+                        <td>
+                            {% if r.equipo %}
+                                <a href="/admin/equipos/editar/{{ r.equipo }}">{{ r.equipo_label ?? r.equipo }}</a>
+                            {% else %}-{% endif %}
+                        </td>
+                        <td>{{ r.tipo_label ?? r.tipo ?? '-' }}</td>
+                        <td>{{ r.fecha_prevista ?? '-' }}</td>
+                        <td>{{ r.fecha_realiza ?? '-' }}</td>
+                        <td>{{ r.comentarios }}</td>
+                        <td style="text-align:right;">
+                            <a href="/admin/equipos/revisiones/editar/{{ r.id }}" class="btn btn-xs btn-default">Editar</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+    <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
+        Revisiones (Stage 9.33, tabla mantenimientos). Calendario y plan de mantenimiento deferred.
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Stage 9.33 — Equipos revisiones shell

Uses legacy table name **`mantenimientos`** (menu `equipos:revision:listado:ver`) for the first modern revisiones slice.

### Delivered
- Patch **0043**: table + 3 demo records linked to equipos 1–2
- CRUD `/admin/equipos/revisiones` (+ nuevo/editar)
- Filter by equipo; prefill `?equipo=`
- Tipos: revisión / preventivo / correctivo
- Equipos list: revisión counts + **+ Revisión**
- Legacy: `/administracion/equipos/revision/listado/ver`
- verify + living docs

### Out of scope
Calendario anual, plan de mantenimiento UI.

### Verify
php -l green · 3 mantenimientos · verify green

Browser: `/admin/equipos` → counts → `/admin/equipos/revisiones` filter + create.

Plan committed first. Docker-only.