### PR TITLE
feat(9.34): Documentación quick workflow (Revisar / Aprobar)

### DIFF
--- a/.agents/MIGRATION-TODOS.md
+++ b/.agents/MIGRATION-TODOS.md
@@ -5,7 +5,7 @@ MIGRATION-PLAN.md = architecture, constraints, high-level stages + history.
 STAGE-CHECKLISTS.md = detailed per-leg playbooks, exact commands, evidence, retrospective lessons.  
 **This file** = scannable "what is left, how big is it, what should the next PR be?" + handoff package for other agents.
 
-**Last updated**: Stage 9.33 on `feat/stage-9.33-equipos-revisiones` (Equipos revisiones / mantenimientos). Previous: 9.32 Auditorías hallazgos.
+**Last updated**: Stage 9.34 on `feat/stage-9.34-documentacion-workflow-actions` (Documentación Revisar/Aprobar quick actions). Previous: 9.33 Equipos revisiones.
 
 ---
 
@@ -102,10 +102,11 @@ Pick 1-2 related items that together form a reviewable PR. Update this list when
 - [x] **Documentación estado/filter polish**: Delivered in Stage 9.31 (estado labels/badges from legacy codes, list filter estado+activo, form select + badge, EstadoHelper, patch 0041). See 9.31 plan and STAGE-CHECKLISTS.
 - [x] **Auditorías hallazgos first slice**: Delivered in Stage 9.32 (`hallazgos_auditoria` table, list/form, filter by auditoría, reverse links on ejecución, optional Mejora FK, patch 0042). See 9.32 plan and STAGE-CHECKLISTS.
 - [x] **Equipos revisiones shell**: Delivered in Stage 9.33 (`mantenimientos` list/form, filter by equipo, reverse counts, prefill, patch 0043). See 9.33 plan and STAGE-CHECKLISTS.
+- [x] **Documentación quick workflow actions**: Delivered in Stage 9.34 (A revisión / Revisar / Aprobar quick POSTs + form checkboxes, auto user/fecha, patch 0044). See 9.34 plan and STAGE-CHECKLISTS.
 - [ ] **Next** (sized picks):  
-  - Documentación quick workflow actions · In: revisar/aprobar buttons like Mejora · Out: rich editor · ~12 files · patch? small  
   - Auditorías plan/horario · In: horario_auditoria shell · Out: informes · ~12 files · patch? yes  
-  - Equipos calendario / plan mantenimiento · In: calendar view shell · Out: full preventivo workflows · ~15 files · patch? maybe
+  - Equipos calendario / plan mantenimiento · In: calendar view shell · Out: full preventivo workflows · ~15 files · patch? maybe  
+  - Documentación rich content / binario · In: richer content editor shell · Out: full GenPDF · ~15 files · patch? maybe
 
 Aim for a mix: one "close the small gaps" + one "new vertical" per couple of legs. Keep delivering working, reviewable increments.
 
@@ -142,8 +143,8 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 - [ ] Calendario + plan mantenimiento / deeper maintenance workflows (tie to Auditorias / Mejora).
 
 ### Documentación (Core ISO — high value, likely larger)
-- [x] Documentación initial shell delivered in Stage 9.5. Tree in 9.12. Editor/perfiles in 9.23, workflows in 9.24, content editor (texto) in 9.26. Estado labels + list filter in 9.31. Full rich editor, binario, more, PDF deferred. See 9.5 + 9.12 + 9.23 + 9.24 + 9.26 + 9.31 plans.
-- [ ] Full tree + editor modernization, perfiles, workflows, formats/plantillas; quick revise/approve transitions.
+- [x] Documentación initial shell delivered in Stage 9.5. Tree in 9.12. Editor/perfiles in 9.23, workflows fields in 9.24, content editor (texto) in 9.26. Estado labels + list filter in 9.31. Quick Revisar/Aprobar transitions in 9.34. Full rich editor, binario, more, PDF deferred. See 9.5 + 9.12 + 9.23 + 9.24 + 9.26 + 9.31 + 9.34 plans.
+- [ ] Full tree + editor modernization, formats/plantillas; rich content / binario.
 - [ ] PDF ficha / export modernization (GenPDF.inc, related) — cross-cutting but surfaces here.
 
 ### Auditorías (Audits)

--- a/.agents/STAGE-CHECKLISTS.md
+++ b/.agents/STAGE-CHECKLISTS.md
@@ -3597,6 +3597,23 @@ docker compose exec db psql -U qnova -d qnova -c "SELECT COUNT(*) FROM mantenimi
 **Branch status:** Stage 9.33 on `feat/stage-9.33-equipos-revisiones`.
 
 
+## Stage 9.34 — Documentación quick workflow actions
+
+**Goal:** One-click Enviar a revisión / Revisar / Aprobar (list + form checkboxes), auto current user + today; approve requires prior review.
+
+**Validation:**
+```bash
+docker compose exec app php -l Pages/Documentacion/Formulario.php index.php
+docker compose exec app ./scripts/init-db.sh
+docker compose exec app ./scripts/verify-8.6.sh
+docker compose exec db psql -U qnova -d qnova -c "SELECT id, estado, revisado_por, aprobado_por FROM documentos ORDER BY id;"
+```
+
+**Browser:** /admin/documentacion — buttons by estado; A revisión → Revisar → Aprobar; form checkboxes; cannot approve without review.
+
+**Branch status:** Stage 9.34 on `feat/stage-9.34-documentacion-workflow-actions`.
+
+
 
 
 

--- a/Pages/Documentacion/Formulario.php
+++ b/Pages/Documentacion/Formulario.php
@@ -1,5 +1,6 @@
 <?php
 namespace Tuqan\Pages\Documentacion;
+use Tuqan\Classes\Config;
 use Tuqan\Pages\Catalog\CatalogFormulario;
 class Formulario extends CatalogFormulario
 {
@@ -107,6 +108,10 @@ class Formulario extends CatalogFormulario
             'fecha_revision'   => trim($_POST['fecha_revision'] ?? ''),
             'fecha_aprobacion' => trim($_POST['fecha_aprobacion'] ?? ''),
             'contenido'        => trim($_POST['contenido'] ?? ''),
+            // 9.34 workflow action checkboxes
+            'accion_enviar_revision' => !empty($_POST['accion_enviar_revision']) ? 1 : 0,
+            'accion_revisar'         => !empty($_POST['accion_revisar']) ? 1 : 0,
+            'accion_aprobar'         => !empty($_POST['accion_aprobar']) ? 1 : 0,
         ];
     }
 
@@ -116,12 +121,46 @@ class Formulario extends CatalogFormulario
         if (($data['nombre'] ?? '') === '') {
             $errors[] = 'El nombre del documento es obligatorio.';
         }
+        // Cannot approve without prior review (form path)
+        if (!empty($data['accion_aprobar']) && empty($data['revisado_por']) && empty($data['accion_revisar'])) {
+            $errors[] = 'No se puede aprobar sin revisar primero.';
+        }
         return $errors;
     }
 
     protected function persist(array $data, $id)
     {
         $db = $this->getDb();
+        $today = date('Y-m-d');
+        $currentUser = $this->getCurrentUserId();
+
+        // 9.34 form workflow auto-apply
+        if (!empty($data['accion_enviar_revision'])) {
+            $data['estado'] = 3; // Pend. revisión
+        }
+        if (!empty($data['accion_revisar'])) {
+            if (empty($data['revisado_por'])) {
+                $data['revisado_por'] = $currentUser;
+            }
+            if (($data['fecha_revision'] ?? '') === '') {
+                $data['fecha_revision'] = $today;
+            }
+            $data['estado'] = 4; // Revisado
+        }
+        if (!empty($data['accion_aprobar'])) {
+            if (empty($data['aprobado_por'])) {
+                $data['aprobado_por'] = $currentUser;
+            }
+            if (($data['fecha_aprobacion'] ?? '') === '') {
+                $data['fecha_aprobacion'] = $today;
+            }
+            if (empty($data['revisado_por'])) {
+                $data['revisado_por'] = $currentUser;
+                $data['fecha_revision'] = $data['fecha_revision'] ?: $today;
+            }
+            $data['estado'] = 1; // En vigor
+        }
+
         $params = [
             $data['nombre'],
             $data['codigo'],
@@ -166,5 +205,118 @@ class Formulario extends CatalogFormulario
             [$doc_id, $data['contenido'], $data['contenido']]
         );
         $db->desconexion();
+    }
+
+    // --- Quick workflow actions (Stage 9.34) — one-click from list ---
+
+    public function EnviarRevision($id = null)
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+        Config::initialize();
+        $id = $id !== null ? (int)$id : (int)($_POST['id'] ?? $_GET['id'] ?? 0);
+        if ($id <= 0) {
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada("SELECT id FROM {$this->table} WHERE id = ?", [$id]);
+        $row = $db->coger_Fila();
+        if (!$row) {
+            $db->desconexion();
+            $_SESSION[$this->flashPrefix . '_form_error'] = 'Documento no encontrado.';
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+        $db->consultaPreparada("UPDATE {$this->table} SET estado = 3 WHERE id = ?", [$id]);
+        $db->desconexion();
+        $_SESSION[$this->flashPrefix . '_flash_success'] = 'Documento enviado a revisión.';
+        header("Location: {$this->listRoute}");
+        exit;
+    }
+
+    public function Revisar($id = null)
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+        Config::initialize();
+        $id = $id !== null ? (int)$id : (int)($_POST['id'] ?? $_GET['id'] ?? 0);
+        if ($id <= 0) {
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada(
+            "SELECT revisado_por, fecha_revision FROM {$this->table} WHERE id = ?",
+            [$id]
+        );
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row) {
+            $_SESSION[$this->flashPrefix . '_form_error'] = 'Documento no encontrado.';
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+        $today = date('Y-m-d');
+        $user = $this->getCurrentUserId();
+        $revUser = $row[0] ?: $user;
+        $revFecha = $row[1] ?: $today;
+        $db = $this->getDb();
+        $db->consultaPreparada(
+            "UPDATE {$this->table} SET revisado_por = ?, fecha_revision = ?, estado = 4 WHERE id = ?",
+            [$revUser, $revFecha, $id]
+        );
+        $db->desconexion();
+        $_SESSION[$this->flashPrefix . '_flash_success'] = 'Documento revisado.';
+        header("Location: {$this->listRoute}");
+        exit;
+    }
+
+    public function Aprobar($id = null)
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+        Config::initialize();
+        $id = $id !== null ? (int)$id : (int)($_POST['id'] ?? $_GET['id'] ?? 0);
+        if ($id <= 0) {
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada(
+            "SELECT revisado_por, aprobado_por, fecha_aprobacion FROM {$this->table} WHERE id = ?",
+            [$id]
+        );
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row) {
+            $_SESSION[$this->flashPrefix . '_form_error'] = 'Documento no encontrado.';
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+        if (empty($row[0])) {
+            $_SESSION[$this->flashPrefix . '_form_error'] = 'No se puede aprobar sin revisar primero. Use Revisar antes de Aprobar.';
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+        $today = date('Y-m-d');
+        $user = $this->getCurrentUserId();
+        $aprUser = $row[1] ?: $user;
+        $aprFecha = $row[2] ?: $today;
+        $db = $this->getDb();
+        $db->consultaPreparada(
+            "UPDATE {$this->table} SET aprobado_por = ?, fecha_aprobacion = ?, estado = 1 WHERE id = ?",
+            [$aprUser, $aprFecha, $id]
+        );
+        $db->desconexion();
+        $_SESSION[$this->flashPrefix . '_flash_success'] = 'Documento aprobado y puesto en vigor.';
+        header("Location: {$this->listRoute}");
+        exit;
     }
 }

--- a/docker/db-init/data-patches/0044-documentacion-workflow-demo.sql
+++ b/docker/db-init/data-patches/0044-documentacion-workflow-demo.sql
@@ -1,0 +1,16 @@
+-- 0044-documentacion-workflow-demo.sql
+-- Stage 9.34: Demo estados so list shows Enviar/Revisar/Aprobar buttons
+-- 1=En vigor, 2=Borrador, 3=Pend. revisión, 4=Revisado, 5=Pend. aprobación
+
+UPDATE documentos SET estado = 2, revisado_por = NULL, fecha_revision = NULL,
+    aprobado_por = NULL, fecha_aprobacion = NULL WHERE id = 1;
+
+UPDATE documentos SET estado = 3, revisado_por = NULL, fecha_revision = NULL,
+    aprobado_por = NULL, fecha_aprobacion = NULL WHERE id = 2;
+
+UPDATE documentos SET estado = 4, revisado_por = 1, fecha_revision = '2025-06-01',
+    aprobado_por = NULL, fecha_aprobacion = NULL WHERE id = 3;
+
+INSERT INTO data_patches (filename, applied_at)
+VALUES ('0044-documentacion-workflow-demo.sql', NOW())
+ON CONFLICT (filename) DO NOTHING;

--- a/index.php
+++ b/index.php
@@ -405,6 +405,11 @@ $router->addRoute('GET', '/admin/documentacion/editar/{id}', ['Tuqan\Pages\Docum
 $router->addRoute('POST', '/admin/documentacion/nuevo', ['Tuqan\Pages\Documentacion\Formulario', 'Procesar'], ['before' => 'auth_company']);
 $router->addRoute('POST', '/admin/documentacion/editar/{id}', ['Tuqan\Pages\Documentacion\Formulario', 'Procesar'], ['before' => 'auth_company']);
 
+// Quick workflow actions (Stage 9.34)
+$router->addRoute('POST', '/admin/documentacion/enviar-revision/{id}', ['Tuqan\Pages\Documentacion\Formulario', 'EnviarRevision'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/documentacion/revisar/{id}', ['Tuqan\Pages\Documentacion\Formulario', 'Revisar'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/documentacion/aprobar/{id}', ['Tuqan\Pages\Documentacion\Formulario', 'Aprobar'], ['before' => 'auth_company']);
+
 // Key legacy for Documentación (vigor / borradores + general)
 $router->addRoute('GET', '/administracion/documentacion/docvigor/listado/ver', ['Tuqan\Pages\Documentacion\Listado', 'ShowPage'], ['before' => 'auth_company']);
 $router->addRoute('GET', '/administracion/documentacion/docborrador/listado/ver', ['Tuqan\Pages\Documentacion\Listado', 'ShowPage'], ['before' => 'auth_company']);

--- a/reference/stage-9.34-documentacion-workflow-actions-plan.md
+++ b/reference/stage-9.34-documentacion-workflow-actions-plan.md
@@ -1,0 +1,22 @@
+# Stage 9.34 — Documentación quick workflow actions
+
+**Status**: Planning (plan first)
+**Branch**: `feat/stage-9.34-documentacion-workflow-actions`
+**Driver**: Sized next after 9.33. Parallel to Mejora 9.28: one-click transitions using existing estado + revisado_por/aprobado_por fields.
+
+## Goals
+1. Quick POST actions: Enviar a revisión → estado 3; Revisar → user+fecha + estado 4; Aprobar → user+fecha + estado 1 (requires prior revisión).
+2. Form checkboxes for same actions with auto-assign current user/today.
+3. List conditional buttons by estado.
+4. Routes; small patch 0044 demo states for all three buttons.
+5. verify + playbook + TODOS.
+
+## Out
+- Rich HTML editor, binario, full audit trail.
+
+## Sizing
+- One outcome: click Revisar/Aprobar on document list/form.
+- ~10 files, 1 small patch.
+
+---
+*Plan committed first. Docker-only.*

--- a/scripts/verify-8.6.sh
+++ b/scripts/verify-8.6.sh
@@ -134,6 +134,12 @@ SELECT '0043-equipos-revisiones.sql' AS patch, COUNT(*) FROM data_patches WHERE 
 SELECT COUNT(*) AS mantenimientos_rows FROM mantenimientos;
 SELECT equipo, COUNT(*) AS n FROM mantenimientos GROUP BY equipo ORDER BY equipo;
 
+-- 9.34 Documentación workflow demo
+SELECT '0044-documentacion-workflow-demo.sql' AS patch, COUNT(*) FROM data_patches WHERE filename = '0044-documentacion-workflow-demo.sql';
+SELECT COUNT(*) AS docs_revisados FROM documentos WHERE revisado_por IS NOT NULL;
+SELECT COUNT(*) AS docs_borrador_or_pend FROM documentos WHERE estado IN (2, 3);
+SELECT COUNT(*) AS docs_revisado_estado FROM documentos WHERE estado = 4;
+
 -- 9.5 Formación (Planes) + Documentación evidence
 SELECT COUNT(*) AS plan_formacion_rows FROM plan_formacion;
 SELECT COUNT(*) AS documentos_rows FROM documentos;

--- a/templates/documentacion/formulario.twig
+++ b/templates/documentacion/formulario.twig
@@ -57,6 +57,28 @@
         </div>
 
         <div class="form-group">
+            <label>Acciones de workflow (auto usuario actual + fecha de hoy si faltan)</label>
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="accion_enviar_revision" value="1">
+                    Enviar a revisión (estado → Pend. revisión)
+                </label>
+            </div>
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="accion_revisar" value="1">
+                    Revisar ahora
+                </label>
+            </div>
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="accion_aprobar" value="1">
+                    Aprobar y poner en vigor (requiere revisado)
+                </label>
+            </div>
+        </div>
+
+        <div class="form-group">
             <label for="revision">Revisión</label>
             <input type="text" class="form-control" id="revision" name="revision"
                    value="{{ documento.revision ?? '' }}">
@@ -177,7 +199,7 @@
         </div>
 
         <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
-            Documentación (9.5–9.26 + 9.31). Estado con etiquetas (En vigor / Borrador / …). Rich editor / binario deferred.
+            Documentación (9.5–9.31 + 9.34). Workflow: enviar a revisión / revisar / aprobar. Rich editor deferred.
         </div>
     </form>
 </div>

--- a/templates/documentacion/listado.twig
+++ b/templates/documentacion/listado.twig
@@ -16,6 +16,13 @@
 </div>
 
 <div style="padding: 20px;">
+    {% if flashSuccess %}
+        <div class="alert alert-success">{{ flashSuccess }}</div>
+    {% endif %}
+    {% if flashError %}
+        <div class="alert alert-danger">{{ flashError }}</div>
+    {% endif %}
+
     <form method="GET" action="/admin/documentacion" class="form-inline" style="margin-bottom: 15px;">
         <div class="form-group" style="margin-right: 8px;">
             <label for="estado" style="margin-right: 6px;">Estado</label>
@@ -54,7 +61,7 @@
                         <th>Revisado por</th>
                         <th>Aprobado por</th>
                         <th>Activo</th>
-                        <th style="width:140px;text-align:right;">Acciones</th>
+                        <th style="width:260px;text-align:right;">Acciones</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -69,8 +76,23 @@
                         <td>{{ d.revisado_por_label ?? (d.revisado_por ?? '-') }}</td>
                         <td>{{ d.aprobado_por_label ?? (d.aprobado_por ?? '-') }}</td>
                         <td>{% if d.activo %}<span class="label label-success">Activo</span>{% else %}<span class="label label-default">Inactivo</span>{% endif %}</td>
-                        <td style="text-align:right;">
+                        <td style="text-align:right; white-space: nowrap;">
                             <a href="/admin/documentacion/editar/{{ d.id }}" class="btn btn-xs btn-default">Editar</a>
+                            {% if d.estado is null or d.estado == 2 %}
+                                <form method="POST" action="/admin/documentacion/enviar-revision/{{ d.id }}" style="display:inline;margin-left:2px;">
+                                    <button type="submit" class="btn btn-xs btn-warning" title="Estado → Pend. revisión">A revisión</button>
+                                </form>
+                            {% endif %}
+                            {% if d.estado is null or d.estado == 2 or d.estado == 3 %}
+                                <form method="POST" action="/admin/documentacion/revisar/{{ d.id }}" style="display:inline;margin-left:2px;">
+                                    <button type="submit" class="btn btn-xs btn-info" title="Marcar revisado">Revisar</button>
+                                </form>
+                            {% endif %}
+                            {% if d.estado == 4 or d.estado == 5 or (d.revisado_por and d.estado != 1 and d.estado != 6) %}
+                                <form method="POST" action="/admin/documentacion/aprobar/{{ d.id }}" style="display:inline;margin-left:2px;">
+                                    <button type="submit" class="btn btn-xs btn-success" title="Aprobar y poner en vigor">Aprobar</button>
+                                </form>
+                            {% endif %}
                         </td>
                     </tr>
                     {% endfor %}
@@ -79,7 +101,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Documentación (9.5–9.26 + 9.31 estado labels/filter). Rich editor / binario deferred.
+        Documentación (9.5–9.31 + 9.34 workflow: A revisión / Revisar / Aprobar). Rich editor deferred.
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Stage 9.34 — Documentación quick workflow actions

Same pattern as Mejora 9.28: one-click transitions on list + form checkboxes.

### Actions
| Action | Effect |
|--------|--------|
| **A revisión** | `estado = 3` (Pend. revisión) |
| **Revisar** | `revisado_por` + `fecha_revision` + `estado = 4` |
| **Aprobar** | requires prior review → `aprobado_por` + `fecha_aprobacion` + `estado = 1` (En vigor) |

### Also
- Form checkboxes with auto current user + today
- Conditional buttons by estado on list
- Flash success/error on list
- Patch **0044** demo (Borrador / Pend. revisión / Revisado)
- Routes, verify, TODOS, playbook

### Out of scope
Rich HTML editor, binario, PDF.

### Verify
php -l green · demo estados 2/3/4 · verify green

Browser: `/admin/documentacion` — A revisión → Revisar → Aprobar; form checkboxes; approve without review shows error.

Plan committed first. Docker-only.