### PR TITLE
feat(9.35): Auditorías horario first slice

### DIFF
--- a/.agents/MIGRATION-TODOS.md
+++ b/.agents/MIGRATION-TODOS.md
@@ -5,7 +5,7 @@ MIGRATION-PLAN.md = architecture, constraints, high-level stages + history.
 STAGE-CHECKLISTS.md = detailed per-leg playbooks, exact commands, evidence, retrospective lessons.  
 **This file** = scannable "what is left, how big is it, what should the next PR be?" + handoff package for other agents.
 
-**Last updated**: Stage 9.34 on `feat/stage-9.34-documentacion-workflow-actions` (Documentación Revisar/Aprobar quick actions). Previous: 9.33 Equipos revisiones.
+**Last updated**: Stage 9.35 on `feat/stage-9.35-auditorias-horario` (Auditorías horario shell). Previous: 9.34 Documentación workflow.
 
 ---
 
@@ -103,10 +103,11 @@ Pick 1-2 related items that together form a reviewable PR. Update this list when
 - [x] **Auditorías hallazgos first slice**: Delivered in Stage 9.32 (`hallazgos_auditoria` table, list/form, filter by auditoría, reverse links on ejecución, optional Mejora FK, patch 0042). See 9.32 plan and STAGE-CHECKLISTS.
 - [x] **Equipos revisiones shell**: Delivered in Stage 9.33 (`mantenimientos` list/form, filter by equipo, reverse counts, prefill, patch 0043). See 9.33 plan and STAGE-CHECKLISTS.
 - [x] **Documentación quick workflow actions**: Delivered in Stage 9.34 (A revisión / Revisar / Aprobar quick POSTs + form checkboxes, auto user/fecha, patch 0044). See 9.34 plan and STAGE-CHECKLISTS.
+- [x] **Auditorías plan/horario first slice**: Delivered in Stage 9.35 (`horario_auditoria` + modern auditoria FK, list/form, filter/prefill, ejecución reverse links, patch 0045). See 9.35 plan and STAGE-CHECKLISTS.
 - [ ] **Next** (sized picks):  
-  - Auditorías plan/horario · In: horario_auditoria shell · Out: informes · ~12 files · patch? yes  
   - Equipos calendario / plan mantenimiento · In: calendar view shell · Out: full preventivo workflows · ~15 files · patch? maybe  
-  - Documentación rich content / binario · In: richer content editor shell · Out: full GenPDF · ~15 files · patch? maybe
+  - Documentación rich content / binario · In: richer content editor shell · Out: full GenPDF · ~15 files · patch? maybe  
+  - Auditorías informes · In: informe fields/export shell · Out: GenPDF full · ~12 files · patch? small
 
 Aim for a mix: one "close the small gaps" + one "new vertical" per couple of legs. Keep delivering working, reviewable increments.
 
@@ -148,8 +149,8 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 - [ ] PDF ficha / export modernization (GenPDF.inc, related) — cross-cutting but surfaces here.
 
 ### Auditorías (Audits)
-- [x] Auditorías (legacy 71) basic slice — `programa_auditoria` delivered in Stage 9.6. Execution first slice (auditorias table basic CRUD + programa link) delivered in Stage 9.19. Mejora reverse links in Stage 9.29. Hallazgos first slice (`hallazgos_auditoria` + CRUD + links) in Stage 9.32. Plan/horario e informes still deferred. See 9.6 + 9.19 + 9.29 + 9.32 plans.
-- [ ] Full execution + plan/horario + informes / deeper follow-up. Integration with Indicadores + Aspectos.
+- [x] Auditorías (legacy 71) basic slice — `programa_auditoria` delivered in Stage 9.6. Execution first slice (auditorias table basic CRUD + programa link) delivered in Stage 9.19. Mejora reverse links in Stage 9.29. Hallazgos first slice in Stage 9.32. Horario shell (`horario_auditoria` + FK) in Stage 9.35. Informes still deferred. See 9.6 + 9.19 + 9.29 + 9.32 + 9.35 plans.
+- [ ] Full execution + informes / deeper follow-up. Integration with Indicadores + Aspectos.
 
 ### Indicadores + Objetivos (KPIs)
 - [x] Indicadores basic (legacy 72) — core `indicadores` table delivered in Stage 9.9 (0027 patch + Pages/Indicadores using enhanced 9.8 bases + templates + routes + verify). Fields: nombre, definicion, valores (inicial/objetivo/tolerable), tecnica, responsables, frecuencias, activo, genera_objetivo. Charts/graphs, full calculations, metas_indicadores, objetivos and dashboard deferred. See 9.9 plan/playbook.

--- a/.agents/STAGE-CHECKLISTS.md
+++ b/.agents/STAGE-CHECKLISTS.md
@@ -3614,6 +3614,23 @@ docker compose exec db psql -U qnova -d qnova -c "SELECT id, estado, revisado_po
 **Branch status:** Stage 9.34 on `feat/stage-9.34-documentacion-workflow-actions`.
 
 
+## Stage 9.35 — Auditorías horario first slice
+
+**Goal:** CRUD for `horario_auditoria` schedule slots linked to ejecución via modern `auditoria` FK; filter/prefill; reverse counts on ejecución.
+
+**Validation:**
+```bash
+docker compose exec app ./scripts/init-db.sh
+docker compose exec app php -l Pages/Auditorias/Horario/Listado.php Pages/Auditorias/Horario/Formulario.php Pages/Auditorias/Ejecucion/Listado.php Pages/Auditorias/Ejecucion/Formulario.php index.php
+docker compose exec app ./scripts/verify-8.6.sh
+docker compose exec db psql -U qnova -d qnova -c "SELECT COUNT(*) FROM horario_auditoria; SELECT auditoria, COUNT(*) FROM horario_auditoria GROUP BY 1;"
+```
+
+**Browser:** /admin/auditorias/horario; filter; create from ejecución + Horario; edit form datetime-local.
+
+**Branch status:** Stage 9.35 on `feat/stage-9.35-auditorias-horario`.
+
+
 
 
 

--- a/Pages/Auditorias/Ejecucion/Formulario.php
+++ b/Pages/Auditorias/Ejecucion/Formulario.php
@@ -49,6 +49,7 @@ class Formulario extends CatalogFormulario
         $vars['programa_options'] = $this->getRelatedOptions('programa_auditoria', 'nombre');
         $vars['mejora_relacionadas'] = [];
         $vars['hallazgos_relacionados'] = [];
+        $vars['horario_relacionado'] = [];
 
         $key = strtolower($this->flashPrefix);
         if (!empty($vars[$key])) {
@@ -56,10 +57,11 @@ class Formulario extends CatalogFormulario
             $a['programa_label'] = $this->getRelatedLabel('programa_auditoria', $a['programa'] ?? null);
             $vars[$key] = $a;
 
-            // 9.29 Mejora + 9.32 hallazgos reverse links
+            // 9.29 Mejora + 9.32 hallazgos + 9.35 horario reverse links
             if (!empty($a['id'])) {
                 $vars['mejora_relacionadas'] = $this->fetchMejoraRelacionadas((int)$a['id']);
                 $vars['hallazgos_relacionados'] = $this->fetchHallazgosRelacionados((int)$a['id']);
+                $vars['horario_relacionado'] = $this->fetchHorarioRelacionado((int)$a['id']);
             }
         }
 
@@ -119,6 +121,34 @@ class Formulario extends CatalogFormulario
                     'tipo'        => $row[3],
                     'gravedad'    => $row[4],
                     'cerrado'     => $row[5],
+                ];
+            }
+            $db->desconexion();
+            return $items;
+        } catch (\Throwable $e) {
+            return [];
+        }
+    }
+
+    /**
+     * Linked horario_auditoria slots (Stage 9.35).
+     */
+    protected function fetchHorarioRelacionado(int $auditoriaId): array
+    {
+        try {
+            $db = $this->getDb();
+            $db->consultaPreparada(
+                'SELECT id, horainicio, horafin, requisito, auditor FROM horario_auditoria WHERE auditoria = ? ORDER BY horainicio NULLS LAST, id',
+                [$auditoriaId]
+            );
+            $items = [];
+            while ($row = $db->coger_Fila()) {
+                $items[] = [
+                    'id'         => $row[0],
+                    'horainicio' => $row[1],
+                    'horafin'    => $row[2],
+                    'requisito'  => $row[3],
+                    'auditor'    => $row[4],
                 ];
             }
             $db->desconexion();

--- a/Pages/Auditorias/Ejecucion/Listado.php
+++ b/Pages/Auditorias/Ejecucion/Listado.php
@@ -34,6 +34,7 @@ class Listado extends CatalogListado
             $item['programa_label'] = $this->getRelatedLabel('programa_auditoria', $item['programa'] ?? null);
             $item['mejora_count'] = $this->countMejoraForAuditoria((int)$item['id']);
             $item['hallazgo_count'] = $this->countHallazgosForAuditoria((int)$item['id']);
+            $item['horario_count'] = $this->countHorarioForAuditoria((int)$item['id']);
         }
         unset($item);
         return $items;
@@ -71,6 +72,25 @@ class Listado extends CatalogListado
             return (int)($row[0] ?? 0);
         } catch (\Throwable $e) {
             $db->desconexion();
+            return 0;
+        }
+    }
+
+    protected function countHorarioForAuditoria(int $auditoriaId): int
+    {
+        if ($auditoriaId <= 0) {
+            return 0;
+        }
+        try {
+            $db = $this->getDb();
+            $db->consultaPreparada(
+                'SELECT COUNT(*) FROM horario_auditoria WHERE auditoria = ?',
+                [$auditoriaId]
+            );
+            $row = $db->coger_Fila();
+            $db->desconexion();
+            return (int)($row[0] ?? 0);
+        } catch (\Throwable $e) {
             return 0;
         }
     }

--- a/Pages/Auditorias/Horario/Formulario.php
+++ b/Pages/Auditorias/Horario/Formulario.php
@@ -1,0 +1,155 @@
+<?php
+namespace Tuqan\Pages\Auditorias\Horario;
+use Tuqan\Pages\Catalog\CatalogFormulario;
+
+class Formulario extends CatalogFormulario
+{
+    protected string $table        = 'horario_auditoria';
+    protected string $title        = 'Franja de Horario';
+    protected string $templateDir  = 'auditorias/horario';
+    protected string $flashPrefix  = 'horario';
+    protected string $listRoute    = '/admin/auditorias/horario';
+
+    protected function getSelectForForm(): string
+    {
+        return "SELECT id, auditoria, horainicio, horafin, requisito, auditor, area FROM {$this->table} WHERE id = ?";
+    }
+
+    protected function loadItem($id): ?array
+    {
+        if ($id <= 0) {
+            return null;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada($this->getSelectForForm(), [$id]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row) {
+            return null;
+        }
+        return [
+            'id'         => $row[0],
+            'auditoria'  => $row[1] ?? null,
+            'horainicio' => self::toDatetimeLocal($row[2] ?? null),
+            'horafin'    => self::toDatetimeLocal($row[3] ?? null),
+            'requisito'  => $row[4] ?? null,
+            'auditor'    => $row[5] ?? null,
+            'area'       => $row[6] ?? null,
+        ];
+    }
+
+    /** HTML datetime-local value */
+    public static function toDatetimeLocal($ts): string
+    {
+        if ($ts === null || $ts === '') {
+            return '';
+        }
+        $t = strtotime((string)$ts);
+        if ($t === false) {
+            return '';
+        }
+        return date('Y-m-d\TH:i', $t);
+    }
+
+    public static function fromDatetimeLocal(string $val): ?string
+    {
+        $val = trim($val);
+        if ($val === '') {
+            return null;
+        }
+        // datetime-local: 2025-01-15T09:00
+        $val = str_replace('T', ' ', $val);
+        if (strlen($val) === 16) {
+            $val .= ':00';
+        }
+        return $val;
+    }
+
+    protected function buildFormVariables(?array $item): array
+    {
+        if ($item === null) {
+            $prefill = (isset($_GET['auditoria']) && $_GET['auditoria'] !== '') ? (int)$_GET['auditoria'] : null;
+            if ($prefill) {
+                $item = [
+                    'id' => null,
+                    'auditoria' => $prefill,
+                    'horainicio' => date('Y-m-d') . 'T09:00',
+                    'horafin' => date('Y-m-d') . 'T11:00',
+                ];
+            }
+        }
+
+        $vars = parent::buildFormVariables($item);
+        if ($item && empty($item['id'])) {
+            $vars['isEdit'] = false;
+            $vars['pageTitle'] = "Nueva {$this->title}";
+        }
+
+        $vars['auditoria_options'] = $this->getRelatedOptions('auditorias', 'nombre');
+        // areas table may be absent on minimal DB; optional free FK id only
+        $vars['area_options'] = [];
+        try {
+            $vars['area_options'] = $this->getRelatedOptions('areas', 'nombre');
+        } catch (\Throwable $e) {
+            // ignore
+        }
+
+        $key = strtolower($this->flashPrefix);
+        if (!empty($vars[$key])) {
+            $h = $vars[$key];
+            $h['auditoria_label'] = $this->getRelatedLabel('auditorias', $h['auditoria'] ?? null);
+            $vars[$key] = $h;
+        }
+        return $vars;
+    }
+
+    protected function getPostData(): array
+    {
+        return [
+            'auditoria'  => isset($_POST['auditoria']) && $_POST['auditoria'] !== '' ? (int)$_POST['auditoria'] : null,
+            'horainicio' => self::fromDatetimeLocal($_POST['horainicio'] ?? ''),
+            'horafin'    => self::fromDatetimeLocal($_POST['horafin'] ?? ''),
+            'requisito'  => trim($_POST['requisito'] ?? ''),
+            'auditor'    => trim($_POST['auditor'] ?? ''),
+            'area'       => isset($_POST['area']) && $_POST['area'] !== '' ? (int)$_POST['area'] : null,
+        ];
+    }
+
+    protected function validate(array $data): array
+    {
+        $errors = [];
+        if (empty($data['auditoria'])) {
+            $errors[] = 'La auditoría es obligatoria.';
+        }
+        if (empty($data['horainicio'])) {
+            $errors[] = 'La hora de inicio es obligatoria.';
+        }
+        return $errors;
+    }
+
+    protected function persist(array $data, $id)
+    {
+        $db = $this->getDb();
+        $params = [
+            $data['auditoria'],
+            $data['horainicio'],
+            $data['horafin'],
+            $data['requisito'] !== '' ? $data['requisito'] : null,
+            $data['auditor'] !== '' ? $data['auditor'] : null,
+            $data['area'],
+        ];
+        if ($id > 0) {
+            $params[] = $id;
+            $db->consultaPreparada(
+                "UPDATE {$this->table} SET auditoria = ?, horainicio = ?, horafin = ?, requisito = ?, auditor = ?, area = ? WHERE id = ?",
+                $params
+            );
+        } else {
+            $db->consultaPreparada(
+                "INSERT INTO {$this->table} (auditoria, horainicio, horafin, requisito, auditor, area) VALUES (?, ?, ?, ?, ?, ?)",
+                $params
+            );
+        }
+        $db->desconexion();
+    }
+}

--- a/Pages/Auditorias/Horario/Listado.php
+++ b/Pages/Auditorias/Horario/Listado.php
@@ -1,0 +1,93 @@
+<?php
+namespace Tuqan\Pages\Auditorias\Horario;
+use Tuqan\Pages\Catalog\CatalogListado;
+
+class Listado extends CatalogListado
+{
+    protected string $table       = 'horario_auditoria';
+    protected string $title       = 'Horario de Auditoría';
+    protected string $templateDir = 'auditorias/horario';
+    protected string $flashPrefix = 'horario';
+
+    protected function getSelectSql(): string
+    {
+        return "SELECT id, auditoria, horainicio, horafin, requisito, auditor, area FROM {$this->table} ORDER BY id";
+    }
+
+    protected function mapRow($row): array
+    {
+        return [
+            'id'         => $row[0],
+            'auditoria'  => $row[1] ?? null,
+            'horainicio' => $row[2] ?? null,
+            'horafin'    => $row[3] ?? null,
+            'requisito'  => $row[4] ?? null,
+            'auditor'    => $row[5] ?? null,
+            'area'       => $row[6] ?? null,
+        ];
+    }
+
+    protected function fetchItems(): array
+    {
+        $filters = $this->getFilterParams();
+        $sql = "SELECT id, auditoria, horainicio, horafin, requisito, auditor, area FROM {$this->table}";
+        $params = [];
+        if ($filters['auditoria'] !== null) {
+            $sql .= ' WHERE auditoria = ?';
+            $params[] = $filters['auditoria'];
+        }
+        $sql .= ' ORDER BY horainicio NULLS LAST, id';
+
+        $db = $this->getDb();
+        if ($params) {
+            $db->consultaPreparada($sql, $params);
+        } else {
+            $db->consulta($sql);
+        }
+        $items = [];
+        while ($row = $db->coger_Fila()) {
+            $items[] = $this->mapRow($row);
+        }
+        $db->desconexion();
+
+        foreach ($items as &$item) {
+            $item['auditoria_label'] = $this->getRelatedLabel('auditorias', $item['auditoria'] ?? null);
+            $item['area_label'] = null;
+            try {
+                $item['area_label'] = $this->getRelatedLabel('areas', $item['area'] ?? null);
+            } catch (\Throwable $e) {
+                // areas may not exist
+            }
+            $item['horainicio_display'] = self::formatTs($item['horainicio'] ?? null);
+            $item['horafin_display'] = self::formatTs($item['horafin'] ?? null);
+        }
+        unset($item);
+        return $items;
+    }
+
+    public static function formatTs($ts): string
+    {
+        if ($ts === null || $ts === '') {
+            return '—';
+        }
+        // Accept "Y-m-d H:i:s" or DateTime-like strings
+        $t = strtotime((string)$ts);
+        if ($t === false) {
+            return (string)$ts;
+        }
+        return date('Y-m-d H:i', $t);
+    }
+
+    protected function buildListVariables(array $items): array
+    {
+        $vars = parent::buildListVariables($items);
+        $vars['horario'] = $items;
+        $filters = $this->getFilterParams();
+        $vars['auditoria_options'] = $this->getRelatedOptions('auditorias', 'nombre');
+        $vars['filter_auditoria'] = $filters['auditoria'];
+        if ($filters['auditoria'] !== null) {
+            $vars['filter_auditoria_label'] = $this->getRelatedLabel('auditorias', $filters['auditoria']);
+        }
+        return $vars;
+    }
+}

--- a/docker/db-init/data-patches/0045-auditorias-horario.sql
+++ b/docker/db-init/data-patches/0045-auditorias-horario.sql
@@ -1,0 +1,37 @@
+-- 0045-auditorias-horario.sql
+-- Stage 9.35: Horario de auditoría (legacy columns + modern auditoria FK)
+
+CREATE TABLE IF NOT EXISTS horario_auditoria (
+    id SERIAL PRIMARY KEY,
+    auditoria INTEGER,
+    horainicio TIMESTAMP WITHOUT TIME ZONE,
+    horafin TIMESTAMP WITHOUT TIME ZONE,
+    requisito VARCHAR(32),
+    auditor VARCHAR(32),
+    area INTEGER
+);
+
+-- If table already existed without auditoria (full schema), add column
+ALTER TABLE horario_auditoria ADD COLUMN IF NOT EXISTS auditoria INTEGER;
+
+INSERT INTO horario_auditoria (auditoria, horainicio, horafin, requisito, auditor, area)
+SELECT 1, '2025-01-15 09:00:00', '2025-01-15 11:00:00', '4.1 Contexto', 'Auditor A', 1
+WHERE NOT EXISTS (
+    SELECT 1 FROM horario_auditoria WHERE requisito = '4.1 Contexto' AND auditoria = 1
+);
+
+INSERT INTO horario_auditoria (auditoria, horainicio, horafin, requisito, auditor, area)
+SELECT 1, '2025-01-15 11:30:00', '2025-01-15 13:00:00', '7.5 Documentación', 'Auditor A', 1
+WHERE NOT EXISTS (
+    SELECT 1 FROM horario_auditoria WHERE requisito = '7.5 Documentación' AND auditoria = 1
+);
+
+INSERT INTO horario_auditoria (auditoria, horainicio, horafin, requisito, auditor, area)
+SELECT 2, '2025-02-10 10:00:00', '2025-02-10 12:00:00', '8.4 Proveedores', 'Auditor B', NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM horario_auditoria WHERE requisito = '8.4 Proveedores' AND auditoria = 2
+);
+
+INSERT INTO data_patches (filename, applied_at)
+VALUES ('0045-auditorias-horario.sql', NOW())
+ON CONFLICT (filename) DO NOTHING;

--- a/index.php
+++ b/index.php
@@ -445,6 +445,13 @@ $router->addRoute('GET', '/admin/auditorias/hallazgos/editar/{id}', ['Tuqan\Page
 $router->addRoute('POST', '/admin/auditorias/hallazgos/nuevo', ['Tuqan\Pages\Auditorias\Hallazgos\Formulario', 'Procesar'], ['before' => 'auth_company']);
 $router->addRoute('POST', '/admin/auditorias/hallazgos/editar/{id}', ['Tuqan\Pages\Auditorias\Hallazgos\Formulario', 'Procesar'], ['before' => 'auth_company']);
 
+// === Auditorías Horario (Stage 9.35 first slice) ===
+$router->addRoute('GET', '/admin/auditorias/horario', ['Tuqan\Pages\Auditorias\Horario\Listado', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/auditorias/horario/nuevo', ['Tuqan\Pages\Auditorias\Horario\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/auditorias/horario/editar/{id}', ['Tuqan\Pages\Auditorias\Horario\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/auditorias/horario/nuevo', ['Tuqan\Pages\Auditorias\Horario\Formulario', 'Procesar'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/auditorias/horario/editar/{id}', ['Tuqan\Pages\Auditorias\Horario\Formulario', 'Procesar'], ['before' => 'auth_company']);
+
 // === Aspectos Ambientales (Stage 9.7 basic slice) ===
 $router->addRoute('GET', '/admin/aspectos', ['Tuqan\Pages\Aspectos\Listado', 'ShowPage'], ['before' => 'auth_company']);
 $router->addRoute('GET', '/admin/aspectos/nuevo', ['Tuqan\Pages\Aspectos\Formulario', 'ShowPage'], ['before' => 'auth_company']);

--- a/reference/stage-9.35-auditorias-horario-plan.md
+++ b/reference/stage-9.35-auditorias-horario-plan.md
@@ -1,0 +1,22 @@
+# Stage 9.35 — Auditorías plan/horario first slice
+
+**Status**: Planning (plan first)
+**Branch**: `feat/stage-9.35-auditorias-horario`
+**Driver**: Sized next after 9.34. Legacy table `horario_auditoria` (horainicio/horafin/requisito/auditor/area) exists in clean schema dump but not in live minimal DB. Add modern `auditoria` FK for ejecución cross-links (same pattern as hallazgos 9.32).
+
+## Goals
+1. Patch **0045**: CREATE `horario_auditoria` (+ `auditoria` column) + demo rows.
+2. `Pages/Auditorias/Horario/{Listado,Formulario}` Catalog CRUD.
+3. Routes `/admin/auditorias/horario`; filter/prefill by auditoría.
+4. Ejecución reverse count + section + **+ Horario** button.
+5. verify + playbook + TODOS.
+
+## Out
+- Informes PDF, full calendar UI, drag schedule.
+
+## Sizing
+- One outcome: manage schedule slots per auditoría.
+- ~12–15 files, 1 patch.
+
+---
+*Plan committed first. Docker-only.*

--- a/scripts/verify-8.6.sh
+++ b/scripts/verify-8.6.sh
@@ -47,7 +47,7 @@ export PGPASSWORD="${DB_PASS:-secret}"
 psql -h "${DB_HOST:-db}" -U qnova -d qnova -v ON_ERROR_STOP=1 -c "
 -- Tables (8.6 + 8.7 + 8.8 + 9.2 + 9.3 + 9.4 + 9.5 + 9.6 + 9.7 + 9.9)
 SELECT tablename FROM pg_tables 
-WHERE schemaname='public' AND tablename IN ('sedes','clientes','criterios','tiposmejora','empresas','tipoaccionesmejora','tiposareas','tipodocumento','tiposamb','tiposimp','tipocursos','proveedores','equipos','acciones_mejora','plan_formacion','documentos','programa_auditoria','aspectos','indicadores','procesos','contenido_procesos','auditorias','cursos','alumnos','contenido_texto','hallazgos_auditoria','mantenimientos')
+WHERE schemaname='public' AND tablename IN ('sedes','clientes','criterios','tiposmejora','empresas','tipoaccionesmejora','tiposareas','tipodocumento','tiposamb','tiposimp','tipocursos','proveedores','equipos','acciones_mejora','plan_formacion','documentos','programa_auditoria','aspectos','indicadores','procesos','contenido_procesos','auditorias','cursos','alumnos','contenido_texto','hallazgos_auditoria','mantenimientos','horario_auditoria')
 ORDER BY tablename;
 
 -- Sedes rename evidence
@@ -139,6 +139,11 @@ SELECT '0044-documentacion-workflow-demo.sql' AS patch, COUNT(*) FROM data_patch
 SELECT COUNT(*) AS docs_revisados FROM documentos WHERE revisado_por IS NOT NULL;
 SELECT COUNT(*) AS docs_borrador_or_pend FROM documentos WHERE estado IN (2, 3);
 SELECT COUNT(*) AS docs_revisado_estado FROM documentos WHERE estado = 4;
+
+-- 9.35 Auditorías horario evidence
+SELECT '0045-auditorias-horario.sql' AS patch, COUNT(*) FROM data_patches WHERE filename = '0045-auditorias-horario.sql';
+SELECT COUNT(*) AS horario_rows FROM horario_auditoria;
+SELECT auditoria, COUNT(*) AS n FROM horario_auditoria WHERE auditoria IS NOT NULL GROUP BY auditoria ORDER BY auditoria;
 
 -- 9.5 Formación (Planes) + Documentación evidence
 SELECT COUNT(*) AS plan_formacion_rows FROM plan_formacion;

--- a/templates/auditorias/ejecucion/formulario.twig
+++ b/templates/auditorias/ejecucion/formulario.twig
@@ -158,10 +158,52 @@
                 </div>
             {% endif %}
         </div>
+
+        <div style="margin-top: 28px; padding-top: 16px; border-top: 1px solid #eee;">
+            <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px;">
+                <h4 style="margin:0; font-size:16px;">Horario</h4>
+                <div>
+                    <a href="/admin/auditorias/horario?auditoria={{ auditoria.id }}" class="btn btn-default btn-sm">Ver en listado</a>
+                    <a href="/admin/auditorias/horario/nuevo?auditoria={{ auditoria.id }}" class="btn btn-primary btn-sm">Nueva franja</a>
+                </div>
+            </div>
+            {% if horario_relacionado is empty %}
+                <div class="alert alert-info" style="margin-bottom:0;">No hay franjas de horario para esta auditoría.</div>
+            {% else %}
+                <div class="table-responsive">
+                    <table class="table table-condensed table-striped">
+                        <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Inicio</th>
+                                <th>Fin</th>
+                                <th>Requisito</th>
+                                <th>Auditor</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for h in horario_relacionado %}
+                            <tr>
+                                <td>{{ h.id }}</td>
+                                <td>{{ h.horainicio ?? '-' }}</td>
+                                <td>{{ h.horafin ?? '-' }}</td>
+                                <td>{{ h.requisito ?? '-' }}</td>
+                                <td>{{ h.auditor ?? '-' }}</td>
+                                <td style="text-align:right;">
+                                    <a href="/admin/auditorias/horario/editar/{{ h.id }}" class="btn btn-xs btn-default">Editar</a>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% endif %}
+        </div>
         {% endif %}
 
         <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
-            Auditorías ejecución (9.19 + 9.29 Mejora + 9.32 Hallazgos). Plan/horario e informes deferred.
+            Auditorías ejecución (9.19–9.35: Mejora, Hallazgos, Horario). Informes deferred.
         </div>
     </form>
 </div>

--- a/templates/auditorias/ejecucion/listado.twig
+++ b/templates/auditorias/ejecucion/listado.twig
@@ -8,6 +8,7 @@
         <h2 style="margin: 0; font-size: 20px;">Auditorías (Ejecución)</h2>
         <div>
             <a href="/admin/auditorias/hallazgos" class="btn btn-default btn-sm">Hallazgos</a>
+            <a href="/admin/auditorias/horario" class="btn btn-default btn-sm">Horario</a>
             <a href="/admin/auditorias/ejecucion/nuevo" class="btn btn-primary btn-sm">
                 <span class="glyphicon glyphicon-plus"></span> Nueva Auditoría
             </a>
@@ -31,7 +32,8 @@
                         <th>Activo</th>
                         <th>Mejora</th>
                         <th>Hallazgos</th>
-                        <th style="width:240px;text-align:right;">Acciones</th>
+                        <th>Horario</th>
+                        <th style="width:280px;text-align:right;">Acciones</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -57,8 +59,16 @@
                                 <span class="text-muted">0</span>
                             {% endif %}
                         </td>
+                        <td>
+                            {% if a.horario_count > 0 %}
+                                <a href="/admin/auditorias/horario?auditoria={{ a.id }}">{{ a.horario_count }}</a>
+                            {% else %}
+                                <span class="text-muted">0</span>
+                            {% endif %}
+                        </td>
                         <td style="text-align:right; white-space: nowrap;">
                             <a href="/admin/auditorias/ejecucion/editar/{{ a.id }}" class="btn btn-xs btn-default">Editar</a>
+                            <a href="/admin/auditorias/horario/nuevo?auditoria={{ a.id }}" class="btn btn-xs btn-warning" title="Nueva franja">+ Horario</a>
                             <a href="/admin/auditorias/hallazgos/nuevo?auditoria={{ a.id }}" class="btn btn-xs btn-info" title="Nuevo hallazgo">+ Hallazgo</a>
                             <a href="/admin/mejora/nuevo?auditoria={{ a.id }}" class="btn btn-xs btn-primary" title="Crear acción de mejora ligada">+ Mejora</a>
                         </td>
@@ -69,7 +79,8 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Auditorías ejecución (9.19 + 9.29 Mejora + 9.32 Hallazgos). Plan/horario e informes deferred.
+        Auditorías ejecución (9.19–9.35: Mejora, Hallazgos, Horario). Informes deferred.
     </div>
 </div>
 {% endblock %}
+

--- a/templates/auditorias/horario/formulario.twig
+++ b/templates/auditorias/horario/formulario.twig
@@ -1,0 +1,89 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}{{ pageTitle }} - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <h2 style="margin: 0; font-size: 20px;">{{ pageTitle }}</h2>
+        <div>
+            <a href="/admin/auditorias/horario" class="btn btn-default btn-sm">Volver al listado</a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px; max-width: 780px;">
+    <form method="POST" action="{{ isEdit ? '/admin/auditorias/horario/editar/' ~ horario.id : '/admin/auditorias/horario/nuevo' }}">
+        {% if isEdit %}
+            <input type="hidden" name="id" value="{{ horario.id }}">
+        {% endif %}
+
+        <div class="form-group">
+            <label for="auditoria">Auditoría</label>
+            <select class="form-control" id="auditoria" name="auditoria" required>
+                <option value="">-- Seleccionar --</option>
+                {% for a in auditoria_options %}
+                    <option value="{{ a.id }}" {% if a.id == horario.auditoria %}selected{% endif %}>{{ a.nombre }}</option>
+                {% endfor %}
+            </select>
+            {% if horario.auditoria %}
+                <p class="help-block" style="margin-top:6px;">
+                    <a href="/admin/auditorias/ejecucion/editar/{{ horario.auditoria }}">Ver auditoría</a>
+                    ·
+                    <a href="/admin/auditorias/horario?auditoria={{ horario.auditoria }}">Otras franjas</a>
+                </p>
+            {% endif %}
+        </div>
+
+        <div class="row">
+            <div class="col-md-6">
+                <div class="form-group">
+                    <label for="horainicio">Inicio</label>
+                    <input type="datetime-local" class="form-control" id="horainicio" name="horainicio"
+                           value="{{ horario.horainicio ?? '' }}" required>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="form-group">
+                    <label for="horafin">Fin</label>
+                    <input type="datetime-local" class="form-control" id="horafin" name="horafin"
+                           value="{{ horario.horafin ?? '' }}">
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label for="requisito">Requisito / cláusula</label>
+            <input type="text" class="form-control" id="requisito" name="requisito"
+                   value="{{ horario.requisito ?? '' }}" maxlength="32" placeholder="ej. 4.1 Contexto">
+        </div>
+
+        <div class="form-group">
+            <label for="auditor">Auditor</label>
+            <input type="text" class="form-control" id="auditor" name="auditor"
+                   value="{{ horario.auditor ?? '' }}" maxlength="32">
+        </div>
+
+        <div class="form-group">
+            <label for="area">Área (id)</label>
+            <select class="form-control" id="area" name="area">
+                <option value="">-- Ninguna --</option>
+                {% for a in area_options|default([]) %}
+                    <option value="{{ a.id }}" {% if a.id == horario.area %}selected{% endif %}>{{ a.nombre }}</option>
+                {% endfor %}
+            </select>
+        </div>
+
+        <div class="form-group" style="margin-top: 20px;">
+            <button type="submit" class="btn btn-primary">
+                {{ isEdit ? 'Guardar cambios' : 'Crear franja' }}
+            </button>
+            <a href="/admin/auditorias/horario" class="btn btn-default" style="margin-left: 8px;">Cancelar</a>
+        </div>
+
+        <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
+            Horario de auditoría (Stage 9.35). Tabla legacy <code>horario_auditoria</code> + FK moderna a ejecución.
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/templates/auditorias/horario/listado.twig
+++ b/templates/auditorias/horario/listado.twig
@@ -1,0 +1,83 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}Horario de Auditoría - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <h2 style="margin: 0; font-size: 20px;">Horario de Auditoría</h2>
+        <div>
+            <a href="/admin/auditorias/ejecucion" class="btn btn-default btn-sm">Ejecución</a>
+            <a href="/admin/auditorias/hallazgos" class="btn btn-default btn-sm">Hallazgos</a>
+            <a href="/admin/auditorias/horario/nuevo{% if filter_auditoria %}?auditoria={{ filter_auditoria }}{% endif %}" class="btn btn-primary btn-sm">
+                <span class="glyphicon glyphicon-plus"></span> Nueva franja
+            </a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px;">
+    {% if flashSuccess %}<div class="alert alert-success">{{ flashSuccess }}</div>{% endif %}
+    {% if flashError %}<div class="alert alert-danger">{{ flashError }}</div>{% endif %}
+
+    <form method="GET" action="/admin/auditorias/horario" class="form-inline" style="margin-bottom: 15px;">
+        <div class="form-group" style="margin-right: 8px;">
+            <label for="auditoria" style="margin-right: 6px;">Auditoría</label>
+            <select class="form-control input-sm" id="auditoria" name="auditoria">
+                <option value="">-- Todas --</option>
+                {% for a in auditoria_options %}
+                    <option value="{{ a.id }}" {% if filter_auditoria == a.id %}selected{% endif %}>{{ a.nombre }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button type="submit" class="btn btn-default btn-sm">Filtrar</button>
+        {% if filter_auditoria %}
+            <a href="/admin/auditorias/horario" class="btn btn-link btn-sm">Quitar filtro</a>
+        {% endif %}
+    </form>
+
+    {% if horario is empty %}
+        <div class="alert alert-info">No hay franjas de horario{% if filter_auditoria %} para esta auditoría{% endif %}.</div>
+    {% else %}
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Inicio</th>
+                        <th>Fin</th>
+                        <th>Auditoría</th>
+                        <th>Requisito</th>
+                        <th>Auditor</th>
+                        <th>Área</th>
+                        <th style="width:100px;text-align:right;">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for h in horario %}
+                    <tr>
+                        <td>{{ h.id }}</td>
+                        <td>{{ h.horainicio_display ?? h.horainicio ?? '-' }}</td>
+                        <td>{{ h.horafin_display ?? h.horafin ?? '-' }}</td>
+                        <td>
+                            {% if h.auditoria %}
+                                <a href="/admin/auditorias/ejecucion/editar/{{ h.auditoria }}">{{ h.auditoria_label ?? h.auditoria }}</a>
+                            {% else %}-{% endif %}
+                        </td>
+                        <td>{{ h.requisito ?? '-' }}</td>
+                        <td>{{ h.auditor ?? '-' }}</td>
+                        <td>{{ h.area_label ?? (h.area ?? '-') }}</td>
+                        <td style="text-align:right;">
+                            <a href="/admin/auditorias/horario/editar/{{ h.id }}" class="btn btn-xs btn-default">Editar</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+    <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
+        Horario de auditoría (Stage 9.35). Informes PDF deferred.
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Stage 9.35 — Auditorías plan/horario first slice

Schedule slots for auditoría ejecución using legacy **`horario_auditoria`** columns plus a modern **`auditoria`** FK (original clean schema had no link to ejecución).

### Delivered
- Patch **0045**: table + 3 demo franjas
- CRUD `/admin/auditorias/horario` (inicio/fin, requisito, auditor, área)
- Filter/prefill by auditoría
- Ejecución: horario counts, **+ Horario**, related section on edit form
- verify + TODOS + playbook

### Out of scope
Informes PDF, full calendar drag-drop.

### Verify
php -l green · 3 horario rows · verify green

Browser: `/admin/auditorias/horario`, filter, create from ejecución **+ Horario**.

Plan committed first. Docker-only.