### PR TITLE
feat(9.36): Equipos calendario annual shell

### DIFF
--- a/.agents/MIGRATION-TODOS.md
+++ b/.agents/MIGRATION-TODOS.md
@@ -5,7 +5,7 @@ MIGRATION-PLAN.md = architecture, constraints, high-level stages + history.
 STAGE-CHECKLISTS.md = detailed per-leg playbooks, exact commands, evidence, retrospective lessons.  
 **This file** = scannable "what is left, how big is it, what should the next PR be?" + handoff package for other agents.
 
-**Last updated**: Stage 9.35 on `feat/stage-9.35-auditorias-horario` (Auditorías horario shell). Previous: 9.34 Documentación workflow.
+**Last updated**: Stage 9.36 on `feat/stage-9.36-equipos-calendario` (Equipos calendario shell). Previous: 9.35 Auditorías horario.
 
 ---
 
@@ -104,8 +104,9 @@ Pick 1-2 related items that together form a reviewable PR. Update this list when
 - [x] **Equipos revisiones shell**: Delivered in Stage 9.33 (`mantenimientos` list/form, filter by equipo, reverse counts, prefill, patch 0043). See 9.33 plan and STAGE-CHECKLISTS.
 - [x] **Documentación quick workflow actions**: Delivered in Stage 9.34 (A revisión / Revisar / Aprobar quick POSTs + form checkboxes, auto user/fecha, patch 0044). See 9.34 plan and STAGE-CHECKLISTS.
 - [x] **Auditorías plan/horario first slice**: Delivered in Stage 9.35 (`horario_auditoria` + modern auditoria FK, list/form, filter/prefill, ejecución reverse links, patch 0045). See 9.35 plan and STAGE-CHECKLISTS.
+- [x] **Equipos calendario first slice**: Delivered in Stage 9.36 (annual calendar over `mantenimientos`, year/equipo filters, tipo markers, links to revisiones, demo patch 0046). See 9.36 plan and STAGE-CHECKLISTS.
 - [ ] **Next** (sized picks):  
-  - Equipos calendario / plan mantenimiento · In: calendar view shell · Out: full preventivo workflows · ~15 files · patch? maybe  
+  - Equipos plan mantenimiento / auto-preventivo · In: plan from mantenimiento_cada · Out: full workflows · ~12 files · patch? maybe  
   - Documentación rich content / binario · In: richer content editor shell · Out: full GenPDF · ~15 files · patch? maybe  
   - Auditorías informes · In: informe fields/export shell · Out: GenPDF full · ~12 files · patch? small
 
@@ -140,8 +141,8 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 - [ ] Homologacion / evaluation flows (common in ISO supplier management).
 
 ### Equipos (Equipment / Assets)
-- [x] Equipos (legacy 70) — basic listado + form (core fields: numero, descripcion, modelo, ubicacion, activo + supporting) in Stage 9.3. Revisiones shell (`mantenimientos` CRUD + links) in Stage 9.33. Calendario y plan mantenimiento deferred. (See 9.3 + 9.33 plans.)
-- [ ] Calendario + plan mantenimiento / deeper maintenance workflows (tie to Auditorias / Mejora).
+- [x] Equipos (legacy 70) — basic listado + form (core fields: numero, descripcion, modelo, ubicacion, activo + supporting) in Stage 9.3. Revisiones shell (`mantenimientos` CRUD + links) in Stage 9.33. Calendario anual shell in Stage 9.36. (See 9.3 + 9.33 + 9.36 plans.)
+- [ ] Plan mantenimiento / auto-preventivo from `mantenimiento_cada` + deeper workflows (tie to Auditorias / Mejora).
 
 ### Documentación (Core ISO — high value, likely larger)
 - [x] Documentación initial shell delivered in Stage 9.5. Tree in 9.12. Editor/perfiles in 9.23, workflows fields in 9.24, content editor (texto) in 9.26. Estado labels + list filter in 9.31. Quick Revisar/Aprobar transitions in 9.34. Full rich editor, binario, more, PDF deferred. See 9.5 + 9.12 + 9.23 + 9.24 + 9.26 + 9.31 + 9.34 plans.

--- a/.agents/STAGE-CHECKLISTS.md
+++ b/.agents/STAGE-CHECKLISTS.md
@@ -3630,6 +3630,22 @@ docker compose exec db psql -U qnova -d qnova -c "SELECT COUNT(*) FROM horario_a
 
 **Branch status:** Stage 9.35 on `feat/stage-9.35-auditorias-horario`.
 
+## Stage 9.36 — Equipos calendario first slice
+
+**Goal:** Annual calendar shell for equipos maintenance dates (`mantenimientos` fecha_prevista / fecha_realiza); year + equipo filters; tipo color markers; year event list; nav from equipos/revisiones; demo patch 0046.
+
+**Validation:**
+```bash
+docker compose exec app ./scripts/init-db.sh
+docker compose exec app php -l Pages/Equipos/Calendario.php index.php
+docker compose exec app ./scripts/verify-8.6.sh
+docker compose exec db psql -U qnova -d qnova -c "SELECT COUNT(*) FROM mantenimientos WHERE comentarios LIKE 'Calendario demo:%'; SELECT date_part('year', COALESCE(fecha_prevista, fecha_realiza)) AS y, COUNT(*) FROM mantenimientos GROUP BY 1 ORDER BY 1;"
+```
+
+**Browser:** `/admin/equipos/calendario`; change year; filter by equipo; click dots → revisiones edit; nav from listados.
+
+**Branch status:** Stage 9.36 on `feat/stage-9.36-equipos-calendario`.
+
 
 
 

--- a/Pages/Equipos/Calendario.php
+++ b/Pages/Equipos/Calendario.php
@@ -1,0 +1,238 @@
+<?php
+namespace Tuqan\Pages\Equipos;
+
+use Tuqan\Pages\Catalog\CatalogListado;
+use Tuqan\Pages\Equipos\Revisiones\Listado as RevisionesListado;
+
+/**
+ * Equipos annual calendar (Stage 9.36 first slice).
+ * Marks days with mantenimientos (fecha_prevista / fecha_realiza).
+ * Full preventivo auto-schedule and ICS deferred.
+ */
+class Calendario extends CatalogListado
+{
+    protected string $table       = 'mantenimientos';
+    protected string $title       = 'Calendario de Equipos';
+    protected string $templateDir = 'equipos';
+    protected string $flashPrefix = 'calendario';
+
+    protected function getSelectSql(): string
+    {
+        return "SELECT id, equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos FROM {$this->table} ORDER BY id";
+    }
+
+    protected function mapRow($row): array
+    {
+        return [
+            'id'             => $row[0],
+            'equipo'         => $row[1] ?? null,
+            'tipo'           => $row[2] ?? null,
+            'fecha_prevista' => $row[3] ?? null,
+            'fecha_realiza'  => $row[4] ?? null,
+            'comentarios'    => $row[5] ?? '',
+            'motivos'        => $row[6] ?? '',
+        ];
+    }
+
+    protected function resolveYear(): int
+    {
+        $year = isset($_GET['year']) ? (int)$_GET['year'] : (int)date('Y');
+        if ($year < 2000 || $year > 2100) {
+            $year = (int)date('Y');
+        }
+        return $year;
+    }
+
+    /**
+     * Events that fall in $year by prevista and/or realiza.
+     *
+     * @return array{events: array, by_date: array}
+     */
+    protected function fetchYearEvents(int $year, ?int $equipoId): array
+    {
+        $start = sprintf('%04d-01-01', $year);
+        $end   = sprintf('%04d-12-31', $year);
+
+        $sql = "SELECT id, equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos
+                FROM {$this->table}
+                WHERE (
+                    (fecha_prevista IS NOT NULL AND fecha_prevista >= ? AND fecha_prevista <= ?)
+                    OR (fecha_realiza IS NOT NULL AND fecha_realiza >= ? AND fecha_realiza <= ?)
+                )";
+        $params = [$start, $end, $start, $end];
+        if ($equipoId !== null && $equipoId > 0) {
+            $sql .= ' AND equipo = ?';
+            $params[] = $equipoId;
+        }
+        $sql .= ' ORDER BY COALESCE(fecha_prevista, fecha_realiza), id';
+
+        $db = $this->getDb();
+        $db->consultaPreparada($sql, $params);
+        $events = [];
+        while ($row = $db->coger_Fila()) {
+            $events[] = $this->mapRow($row);
+        }
+        $db->desconexion();
+
+        foreach ($events as &$ev) {
+            $ev['equipo_label'] = $this->getEquipoLabel($ev['equipo'] ?? null);
+            $ev['tipo_label']   = RevisionesListado::tipoLabel($ev['tipo'] ?? null);
+            $ev['tipo_class']   = $this->tipoCssClass($ev['tipo'] ?? null);
+        }
+        unset($ev);
+
+        $byDate = [];
+        foreach ($events as $ev) {
+            foreach (['fecha_prevista', 'fecha_realiza'] as $field) {
+                $d = $ev[$field] ?? null;
+                if (!$d) {
+                    continue;
+                }
+                // Normalize to Y-m-d (DB may return timestamp-ish strings)
+                $ymd = substr((string)$d, 0, 10);
+                if (strlen($ymd) < 10 || (int)substr($ymd, 0, 4) !== $year) {
+                    continue;
+                }
+                if (!isset($byDate[$ymd])) {
+                    $byDate[$ymd] = [];
+                }
+                // One marker per mantenimiento per day (even if prevista == realiza)
+                $already = false;
+                foreach ($byDate[$ymd] as $existing) {
+                    if ((int)$existing['id'] === (int)$ev['id']) {
+                        $already = true;
+                        break;
+                    }
+                }
+                if ($already) {
+                    continue;
+                }
+                $copy = $ev;
+                $copy['_field'] = $field;
+                $copy['date_kind'] = $field === 'fecha_prevista' ? 'prevista' : 'realizada';
+                $byDate[$ymd][] = $copy;
+            }
+        }
+
+        return ['events' => $events, 'by_date' => $byDate];
+    }
+
+    protected function tipoCssClass(?string $tipo): string
+    {
+        $map = [
+            'revision'   => 'cal-tipo-revision',
+            'preventivo' => 'cal-tipo-preventivo',
+            'correctivo' => 'cal-tipo-correctivo',
+        ];
+        return $map[$tipo ?? ''] ?? 'cal-tipo-otro';
+    }
+
+    protected function getEquipoLabel($id): ?string
+    {
+        if (!$id) {
+            return null;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada('SELECT id, numero, descripcion FROM equipos WHERE id = ?', [(int)$id]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row) {
+            return null;
+        }
+        return $row[1] . ' — ' . $row[2];
+    }
+
+    protected function getEquipoOptions(): array
+    {
+        $db = $this->getDb();
+        $db->consulta('SELECT id, numero, descripcion FROM equipos ORDER BY numero');
+        $opts = [];
+        while ($row = $db->coger_Fila()) {
+            $opts[] = ['id' => $row[0], 'nombre' => $row[1] . ' — ' . $row[2]];
+        }
+        $db->desconexion();
+        return $opts;
+    }
+
+    /**
+     * Build 12 months of week rows (Mon-first). Each day: day, ymd, is_today, events[].
+     */
+    protected function buildMonths(int $year, array $byDate): array
+    {
+        $today = date('Y-m-d');
+        $monthNames = [
+            1 => 'Enero', 2 => 'Febrero', 3 => 'Marzo', 4 => 'Abril',
+            5 => 'Mayo', 6 => 'Junio', 7 => 'Julio', 8 => 'Agosto',
+            9 => 'Septiembre', 10 => 'Octubre', 11 => 'Noviembre', 12 => 'Diciembre',
+        ];
+        $months = [];
+        for ($m = 1; $m <= 12; $m++) {
+            $daysInMonth = (int)date('t', mktime(0, 0, 0, $m, 1, $year));
+            // ISO weekday: Mon=1 … Sun=7
+            $startDow = (int)date('N', mktime(0, 0, 0, $m, 1, $year));
+            $weeks = [];
+            $week = array_fill(0, 7, null);
+            for ($pad = 1; $pad < $startDow; $pad++) {
+                $week[$pad - 1] = null;
+            }
+            $col = $startDow - 1;
+            for ($d = 1; $d <= $daysInMonth; $d++) {
+                $ymd = sprintf('%04d-%02d-%02d', $year, $m, $d);
+                $week[$col] = [
+                    'day'      => $d,
+                    'ymd'      => $ymd,
+                    'is_today' => ($ymd === $today),
+                    'events'   => $byDate[$ymd] ?? [],
+                    'has'      => !empty($byDate[$ymd]),
+                ];
+                $col++;
+                if ($col === 7) {
+                    $weeks[] = $week;
+                    $week = array_fill(0, 7, null);
+                    $col = 0;
+                }
+            }
+            if ($col > 0) {
+                $weeks[] = $week;
+            }
+            $months[] = [
+                'num'   => $m,
+                'name'  => $monthNames[$m],
+                'weeks' => $weeks,
+            ];
+        }
+        return $months;
+    }
+
+    public function ShowPage()
+    {
+        $twig = $this->initTwig();
+        $year = $this->resolveYear();
+        $filters = $this->getFilterParams();
+        $equipoId = $filters['equipo'] ?? null;
+
+        $fetched = $this->fetchYearEvents($year, $equipoId);
+        $months = $this->buildMonths($year, $fetched['by_date']);
+
+        $vars = array_merge($this->buildCommonVariables(), [
+            'pageTitle'        => $this->title,
+            'year'             => $year,
+            'prev_year'        => $year - 1,
+            'next_year'        => $year + 1,
+            'months'           => $months,
+            'events'           => $fetched['events'],
+            'event_count'      => count($fetched['events']),
+            'equipo_options'   => $this->getEquipoOptions(),
+            'filter_equipo'    => $equipoId,
+            'filter_equipo_label' => $equipoId ? $this->getEquipoLabel($equipoId) : null,
+            'today'            => date('Y-m-d'),
+        ]);
+
+        try {
+            $template = $twig->load($this->templateDir . '/calendario.twig');
+            return $template->render($vars);
+        } catch (\Exception $e) {
+            return "Error al cargar {$this->title}: " . $e->getMessage();
+        }
+    }
+}

--- a/docker/db-init/data-patches/0046-equipos-calendario.sql
+++ b/docker/db-init/data-patches/0046-equipos-calendario.sql
@@ -1,0 +1,52 @@
+-- 0046-equipos-calendario.sql
+-- Stage 9.36: Demo mantenimientos with dates in the current calendar year
+-- so /admin/equipos/calendario shows markers after init-db.
+-- No schema change (reuses mantenimientos from 0043 / clean schema).
+
+INSERT INTO mantenimientos (equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos)
+SELECT 1, 'preventivo',
+       (date_trunc('year', CURRENT_DATE) + INTERVAL '1 month' + INTERVAL '14 days')::date,
+       (date_trunc('year', CURRENT_DATE) + INTERVAL '1 month' + INTERVAL '16 days')::date,
+       'Calendario demo: preventivo febrero',
+       'Seed 9.36'
+WHERE EXISTS (SELECT 1 FROM equipos WHERE id = 1)
+  AND NOT EXISTS (
+    SELECT 1 FROM mantenimientos WHERE comentarios = 'Calendario demo: preventivo febrero'
+  );
+
+INSERT INTO mantenimientos (equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos)
+SELECT 1, 'revision',
+       (date_trunc('year', CURRENT_DATE) + INTERVAL '6 months' + INTERVAL '9 days')::date,
+       (date_trunc('year', CURRENT_DATE) + INTERVAL '6 months' + INTERVAL '10 days')::date,
+       'Calendario demo: revisión julio',
+       'Seed 9.36'
+WHERE EXISTS (SELECT 1 FROM equipos WHERE id = 1)
+  AND NOT EXISTS (
+    SELECT 1 FROM mantenimientos WHERE comentarios = 'Calendario demo: revisión julio'
+  );
+
+INSERT INTO mantenimientos (equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos)
+SELECT 2, 'correctivo',
+       NULL,
+       (date_trunc('year', CURRENT_DATE) + INTERVAL '3 months' + INTERVAL '4 days')::date,
+       'Calendario demo: correctivo abril',
+       'Avería puntual (seed 9.36)'
+WHERE EXISTS (SELECT 1 FROM equipos WHERE id = 2)
+  AND NOT EXISTS (
+    SELECT 1 FROM mantenimientos WHERE comentarios = 'Calendario demo: correctivo abril'
+  );
+
+INSERT INTO mantenimientos (equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos)
+SELECT 2, 'preventivo',
+       (date_trunc('year', CURRENT_DATE) + INTERVAL '9 months' + INTERVAL '19 days')::date,
+       (date_trunc('year', CURRENT_DATE) + INTERVAL '9 months' + INTERVAL '19 days')::date,
+       'Calendario demo: preventivo octubre (prevista)',
+       'Seed 9.36 (fecha_realiza = prevista; columna NOT NULL en legacy)'
+WHERE EXISTS (SELECT 1 FROM equipos WHERE id = 2)
+  AND NOT EXISTS (
+    SELECT 1 FROM mantenimientos WHERE comentarios = 'Calendario demo: preventivo octubre (prevista)'
+  );
+
+INSERT INTO data_patches (filename, applied_at)
+VALUES ('0046-equipos-calendario.sql', NOW())
+ON CONFLICT (filename) DO NOTHING;

--- a/index.php
+++ b/index.php
@@ -349,6 +349,11 @@ $router->addRoute('POST', '/admin/equipos/revisiones/editar/{id}', ['Tuqan\Pages
 // Legacy menu: equipos:revision:listado:ver
 $router->addRoute('GET', '/administracion/equipos/revision/listado/ver', ['Tuqan\Pages\Equipos\Revisiones\Listado', 'ShowPage'], ['before' => 'auth_company']);
 
+// === Equipos Calendario (Stage 9.36) ===
+$router->addRoute('GET', '/admin/equipos/calendario', ['Tuqan\Pages\Equipos\Calendario', 'ShowPage'], ['before' => 'auth_company']);
+// Legacy menu: equipos:calendario:listado:ver
+$router->addRoute('GET', '/administracion/equipos/calendario/listado/ver', ['Tuqan\Pages\Equipos\Calendario', 'ShowPage'], ['before' => 'auth_company']);
+
 // === Mejora / Acciones de Mejora (Stage 9.4) ===
 $router->addRoute('GET', '/admin/mejora', ['Tuqan\Pages\Mejora\Listado', 'ShowPage'], ['before' => 'auth_company']);
 $router->addRoute('GET', '/admin/mejora/nuevo', ['Tuqan\Pages\Mejora\Formulario', 'ShowPage'], ['before' => 'auth_company']);

--- a/reference/stage-9.36-equipos-calendario-plan.md
+++ b/reference/stage-9.36-equipos-calendario-plan.md
@@ -1,0 +1,25 @@
+# Stage 9.36 — Equipos calendario first slice
+
+**Status**: Planning (plan first)
+**Branch**: `feat/stage-9.36-equipos-calendario`
+**Driver**: Sized next after 9.35. Legacy menu `equipos:calendario:listado:ver` + `calendario.inc.php` year view marking mantenimiento dates. Revisiones CRUD already modern (9.33, table `mantenimientos`).
+
+## Goals
+1. Patch **0046**: demo `mantenimientos` rows with dates in the current year (so the calendar is visible after init).
+2. `Pages/Equipos/Calendario.php` — annual calendar shell over `mantenimientos` (fecha_prevista / fecha_realiza).
+3. Routes `/admin/equipos/calendario` + legacy path mapping when needed.
+4. Year nav (`?year=`), optional `?equipo=` filter; day markers by tipo (revisión / preventivo / correctivo); event list + links to revisiones edit.
+5. Nav from equipos list + revisiones list.
+6. verify + playbook + TODOS.
+
+## Out
+- Full preventivo auto-scheduling from `mantenimiento_cada` / dias.
+- Correctivo-only workflows deeper than existing revisiones form.
+- Drag-drop calendar, ICS export, email reminders.
+
+## Sizing
+- One outcome: clickable annual calendar of maintenance/revision dates.
+- ~10–14 files, 1 small data patch (demo only; no new table).
+
+---
+*Plan committed first. Docker-only.*

--- a/reference/stage-9.36-equipos-calendario-plan.md
+++ b/reference/stage-9.36-equipos-calendario-plan.md
@@ -1,6 +1,6 @@
 # Stage 9.36 — Equipos calendario first slice
 
-**Status**: Planning (plan first)
+**Status**: Implemented (verify + PR)
 **Branch**: `feat/stage-9.36-equipos-calendario`
 **Driver**: Sized next after 9.35. Legacy menu `equipos:calendario:listado:ver` + `calendario.inc.php` year view marking mantenimiento dates. Revisiones CRUD already modern (9.33, table `mantenimientos`).
 

--- a/scripts/verify-8.6.sh
+++ b/scripts/verify-8.6.sh
@@ -145,6 +145,13 @@ SELECT '0045-auditorias-horario.sql' AS patch, COUNT(*) FROM data_patches WHERE 
 SELECT COUNT(*) AS horario_rows FROM horario_auditoria;
 SELECT auditoria, COUNT(*) AS n FROM horario_auditoria WHERE auditoria IS NOT NULL GROUP BY auditoria ORDER BY auditoria;
 
+-- 9.36 Equipos calendario evidence (demo rows in current year)
+SELECT '0046-equipos-calendario.sql' AS patch, COUNT(*) FROM data_patches WHERE filename = '0046-equipos-calendario.sql';
+SELECT COUNT(*) AS mantenimientos_current_year FROM mantenimientos
+ WHERE (fecha_prevista IS NOT NULL AND date_part('year', fecha_prevista) = date_part('year', CURRENT_DATE))
+    OR (fecha_realiza IS NOT NULL AND date_part('year', fecha_realiza) = date_part('year', CURRENT_DATE));
+SELECT COUNT(*) AS calendario_demo_rows FROM mantenimientos WHERE comentarios LIKE 'Calendario demo:%';
+
 -- 9.5 Formación (Planes) + Documentación evidence
 SELECT COUNT(*) AS plan_formacion_rows FROM plan_formacion;
 SELECT COUNT(*) AS documentos_rows FROM documentos;

--- a/templates/equipos/calendario.twig
+++ b/templates/equipos/calendario.twig
@@ -1,0 +1,152 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}{{ pageTitle }} - Tuqan{% endblock %}
+
+{% block content %}
+<style>
+.cal-year-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 16px; }
+.cal-month { border: 1px solid #ddd; border-radius: 4px; background: #fff; overflow: hidden; }
+.cal-month h4 { margin: 0; padding: 8px 10px; background: #f5f5f5; border-bottom: 1px solid #ddd; font-size: 14px; }
+.cal-month table { width: 100%; border-collapse: collapse; table-layout: fixed; font-size: 12px; }
+.cal-month th { text-align: center; padding: 4px 0; color: #666; font-weight: 600; background: #fafafa; }
+.cal-month td { text-align: center; vertical-align: top; height: 36px; padding: 2px; border-top: 1px solid #f0f0f0; }
+.cal-day { display: block; min-height: 32px; border-radius: 3px; padding: 2px; }
+.cal-day-num { font-weight: 600; }
+.cal-day.is-today { background: #d9edf7; outline: 1px solid #5bc0de; }
+.cal-day.has-events { cursor: pointer; }
+.cal-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin: 0 1px; }
+.cal-tipo-revision { background: #337ab7; }
+.cal-tipo-preventivo { background: #5cb85c; }
+.cal-tipo-correctivo { background: #f0ad4e; }
+.cal-tipo-otro { background: #999; }
+.cal-legend span { margin-right: 12px; font-size: 12px; }
+.cal-legend .cal-dot { vertical-align: middle; margin-right: 4px; }
+</style>
+
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 8px;">
+        <h2 style="margin: 0; font-size: 20px;">{{ pageTitle }}</h2>
+        <div>
+            <a href="/admin/equipos" class="btn btn-default btn-sm">Equipos</a>
+            <a href="/admin/equipos/revisiones{% if filter_equipo %}?equipo={{ filter_equipo }}{% endif %}" class="btn btn-default btn-sm">Revisiones</a>
+            <a href="/admin/equipos/revisiones/nuevo{% if filter_equipo %}?equipo={{ filter_equipo }}{% endif %}" class="btn btn-primary btn-sm">
+                <span class="glyphicon glyphicon-plus"></span> Nueva Revisión
+            </a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px;">
+    <form method="GET" action="/admin/equipos/calendario" class="form-inline" style="margin-bottom: 15px;">
+        <div class="form-group" style="margin-right: 8px;">
+            <label for="year" style="margin-right: 6px;">Año</label>
+            <input type="number" class="form-control input-sm" id="year" name="year" value="{{ year }}" min="2000" max="2100" style="width: 90px;">
+        </div>
+        <div class="form-group" style="margin-right: 8px;">
+            <label for="equipo" style="margin-right: 6px;">Equipo</label>
+            <select class="form-control input-sm" id="equipo" name="equipo">
+                <option value="">-- Todos --</option>
+                {% for e in equipo_options %}
+                    <option value="{{ e.id }}" {% if filter_equipo == e.id %}selected{% endif %}>{{ e.nombre }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button type="submit" class="btn btn-default btn-sm">Aplicar</button>
+        <a href="/admin/equipos/calendario?year={{ prev_year }}{% if filter_equipo %}&equipo={{ filter_equipo }}{% endif %}" class="btn btn-link btn-sm">← {{ prev_year }}</a>
+        <a href="/admin/equipos/calendario?year={{ next_year }}{% if filter_equipo %}&equipo={{ filter_equipo }}{% endif %}" class="btn btn-link btn-sm">{{ next_year }} →</a>
+        {% if filter_equipo %}
+            <a href="/admin/equipos/calendario?year={{ year }}" class="btn btn-link btn-sm">Quitar filtro equipo</a>
+        {% endif %}
+    </form>
+
+    <div class="cal-legend" style="margin-bottom: 12px;">
+        <span><i class="cal-dot cal-tipo-revision"></i> Revisión</span>
+        <span><i class="cal-dot cal-tipo-preventivo"></i> Preventivo</span>
+        <span><i class="cal-dot cal-tipo-correctivo"></i> Correctivo</span>
+        <span class="text-muted">· {{ event_count }} registro(s) en {{ year }}{% if filter_equipo_label %} · {{ filter_equipo_label }}{% endif %}</span>
+    </div>
+
+    <div class="cal-year-grid">
+        {% for month in months %}
+        <div class="cal-month">
+            <h4>{{ month.name }} {{ year }}</h4>
+            <table>
+                <thead>
+                    <tr>
+                        <th>L</th><th>M</th><th>X</th><th>J</th><th>V</th><th>S</th><th>D</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for week in month.weeks %}
+                    <tr>
+                        {% for cell in week %}
+                        <td>
+                            {% if cell %}
+                            <div class="cal-day{% if cell.is_today %} is-today{% endif %}{% if cell.has %} has-events{% endif %}"
+                                 {% if cell.has %}title="{% for ev in cell.events %}{{ ev.tipo_label }} · {{ ev.equipo_label ?? 'Equipo' }} ({{ ev.date_kind }}){% if not loop.last %}&#10;{% endif %}{% endfor %}"{% endif %}>
+                                <span class="cal-day-num">{{ cell.day }}</span>
+                                {% if cell.has %}
+                                <div>
+                                    {% for ev in cell.events|slice(0, 3) %}
+                                    <a href="/admin/equipos/revisiones/editar/{{ ev.id }}" class="cal-dot {{ ev.tipo_class }}" title="{{ ev.tipo_label }} · {{ ev.equipo_label ?? '' }}"></a>
+                                    {% endfor %}
+                                    {% if cell.events|length > 3 %}<span class="text-muted">+</span>{% endif %}
+                                </div>
+                                {% endif %}
+                            </div>
+                            {% endif %}
+                        </td>
+                        {% endfor %}
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endfor %}
+    </div>
+
+    <h3 style="margin-top: 28px; font-size: 16px;">Registros del año {{ year }}</h3>
+    {% if events is empty %}
+        <div class="alert alert-info">No hay revisiones/mantenimientos con fecha en {{ year }}{% if filter_equipo %} para este equipo{% endif %}.</div>
+    {% else %}
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Equipo</th>
+                        <th>Tipo</th>
+                        <th>Prevista</th>
+                        <th>Realizada</th>
+                        <th>Comentarios</th>
+                        <th style="width:100px;text-align:right;">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for r in events %}
+                    <tr>
+                        <td>{{ r.id }}</td>
+                        <td>
+                            {% if r.equipo %}
+                                <a href="/admin/equipos/editar/{{ r.equipo }}">{{ r.equipo_label ?? r.equipo }}</a>
+                            {% else %}-{% endif %}
+                        </td>
+                        <td><span class="label label-default {{ r.tipo_class }}">{{ r.tipo_label ?? r.tipo ?? '-' }}</span></td>
+                        <td>{{ r.fecha_prevista ?? '-' }}</td>
+                        <td>{{ r.fecha_realiza ?? '-' }}</td>
+                        <td>{{ r.comentarios }}</td>
+                        <td style="text-align:right;">
+                            <a href="/admin/equipos/revisiones/editar/{{ r.id }}" class="btn btn-xs btn-default">Editar</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+
+    <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
+        Calendario anual (Stage 9.36) sobre tabla <code>mantenimientos</code>. Auto-plan preventivo y export ICS deferred.
+    </div>
+</div>
+{% endblock %}

--- a/templates/equipos/listado.twig
+++ b/templates/equipos/listado.twig
@@ -8,6 +8,7 @@
         <h2 style="margin: 0; font-size: 20px;">Equipos</h2>
         <div>
             <a href="/admin/equipos/revisiones" class="btn btn-default btn-sm">Revisiones</a>
+            <a href="/admin/equipos/calendario" class="btn btn-default btn-sm">Calendario</a>
             <a href="/admin/equipos/nuevo" class="btn btn-primary btn-sm">
                 <span class="glyphicon glyphicon-plus"></span> Nuevo Equipo
             </a>
@@ -60,7 +61,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Equipos (9.3 + 9.33 revisiones). Calendario y plan de mantenimiento deferred.
+        Equipos (9.3 + 9.33 revisiones + 9.36 calendario). Auto-plan preventivo deferred.
     </div>
 </div>
 {% endblock %}

--- a/templates/equipos/revisiones/listado.twig
+++ b/templates/equipos/revisiones/listado.twig
@@ -8,6 +8,7 @@
         <h2 style="margin: 0; font-size: 20px;">Revisiones de Equipos</h2>
         <div>
             <a href="/admin/equipos" class="btn btn-default btn-sm">Equipos</a>
+            <a href="/admin/equipos/calendario{% if filter_equipo %}?equipo={{ filter_equipo }}{% endif %}" class="btn btn-default btn-sm">Calendario</a>
             <a href="/admin/equipos/revisiones/nuevo{% if filter_equipo %}?equipo={{ filter_equipo }}{% endif %}" class="btn btn-primary btn-sm">
                 <span class="glyphicon glyphicon-plus"></span> Nueva Revisión
             </a>
@@ -71,7 +72,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Revisiones (Stage 9.33, tabla mantenimientos). Calendario y plan de mantenimiento deferred.
+        Revisiones (Stage 9.33, tabla mantenimientos). Calendario anual en Stage 9.36.
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Annual calendar at `/admin/equipos/calendario` over `mantenimientos` (fecha_prevista / fecha_realiza)
- Year navigation + optional equipo filter; tipo color markers (revisión / preventivo / correctivo)
- Event list for the year with links to revisiones edit; nav from equipos + revisiones lists
- Demo patch **0046** seeds current-year dates so markers show after init
- Legacy path `/administracion/equipos/calendario/listado/ver`

## Out of scope
- Auto-plan preventivo from `mantenimiento_cada`
- ICS export / drag-drop / deeper correctivo workflows

## Test plan
- [ ] `docker compose exec app ./scripts/init-db.sh` (clean room or apply 0046)
- [ ] `docker compose exec app php -l Pages/Equipos/Calendario.php index.php`
- [ ] `docker compose exec app ./scripts/verify-8.6.sh` (0046 + current-year counts)
- [ ] Browser: `/admin/equipos/calendario` — change year, filter equipo, click dots → edit revisión
- [ ] Nav from `/admin/equipos` and `/admin/equipos/revisiones`