### PR TITLE
feat(9.37): Auditorías informes shell + ficha HTML

### DIFF
--- a/.agents/MIGRATION-TODOS.md
+++ b/.agents/MIGRATION-TODOS.md
@@ -5,7 +5,7 @@ MIGRATION-PLAN.md = architecture, constraints, high-level stages + history.
 STAGE-CHECKLISTS.md = detailed per-leg playbooks, exact commands, evidence, retrospective lessons.  
 **This file** = scannable "what is left, how big is it, what should the next PR be?" + handoff package for other agents.
 
-**Last updated**: Stage 9.36 on `feat/stage-9.36-equipos-calendario` (Equipos calendario shell). Previous: 9.35 Auditorías horario.
+**Last updated**: Stage 9.37 on `feat/stage-9.37-auditorias-informes` (Auditorías informes shell). Previous: 9.36 Equipos calendario.
 
 ---
 
@@ -105,10 +105,11 @@ Pick 1-2 related items that together form a reviewable PR. Update this list when
 - [x] **Documentación quick workflow actions**: Delivered in Stage 9.34 (A revisión / Revisar / Aprobar quick POSTs + form checkboxes, auto user/fecha, patch 0044). See 9.34 plan and STAGE-CHECKLISTS.
 - [x] **Auditorías plan/horario first slice**: Delivered in Stage 9.35 (`horario_auditoria` + modern auditoria FK, list/form, filter/prefill, ejecución reverse links, patch 0045). See 9.35 plan and STAGE-CHECKLISTS.
 - [x] **Equipos calendario first slice**: Delivered in Stage 9.36 (annual calendar over `mantenimientos`, year/equipo filters, tipo markers, links to revisiones, demo patch 0046). See 9.36 plan and STAGE-CHECKLISTS.
+- [x] **Auditorías informes first slice**: Delivered in Stage 9.37 (conclusiones/recomendaciones columns, informe edit + printable HTML ficha, links from ejecución, patch 0047). See 9.37 plan and STAGE-CHECKLISTS.
 - [ ] **Next** (sized picks):  
   - Equipos plan mantenimiento / auto-preventivo · In: plan from mantenimiento_cada · Out: full workflows · ~12 files · patch? maybe  
   - Documentación rich content / binario · In: richer content editor shell · Out: full GenPDF · ~15 files · patch? maybe  
-  - Auditorías informes · In: informe fields/export shell · Out: GenPDF full · ~12 files · patch? small
+  - Auditorías GenPDF / formal export · In: PDF from ficha · Out: full GenPDF suite · ~10 files · patch? no
 
 Aim for a mix: one "close the small gaps" + one "new vertical" per couple of legs. Keep delivering working, reviewable increments.
 
@@ -150,8 +151,8 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 - [ ] PDF ficha / export modernization (GenPDF.inc, related) — cross-cutting but surfaces here.
 
 ### Auditorías (Audits)
-- [x] Auditorías (legacy 71) basic slice — `programa_auditoria` delivered in Stage 9.6. Execution first slice (auditorias table basic CRUD + programa link) delivered in Stage 9.19. Mejora reverse links in Stage 9.29. Hallazgos first slice in Stage 9.32. Horario shell (`horario_auditoria` + FK) in Stage 9.35. Informes still deferred. See 9.6 + 9.19 + 9.29 + 9.32 + 9.35 plans.
-- [ ] Full execution + informes / deeper follow-up. Integration with Indicadores + Aspectos.
+- [x] Auditorías (legacy 71) basic slice — `programa_auditoria` delivered in Stage 9.6. Execution first slice (auditorias table basic CRUD + programa link) delivered in Stage 9.19. Mejora reverse links in Stage 9.29. Hallazgos first slice in Stage 9.32. Horario shell (`horario_auditoria` + FK) in Stage 9.35. Informes shell (conclusiones/recomendaciones + HTML ficha) in Stage 9.37. See 9.6 + 9.19 + 9.29 + 9.32 + 9.35 + 9.37 plans.
+- [ ] GenPDF formal export + deeper follow-up. Integration with Indicadores + Aspectos.
 
 ### Indicadores + Objetivos (KPIs)
 - [x] Indicadores basic (legacy 72) — core `indicadores` table delivered in Stage 9.9 (0027 patch + Pages/Indicadores using enhanced 9.8 bases + templates + routes + verify). Fields: nombre, definicion, valores (inicial/objetivo/tolerable), tecnica, responsables, frecuencias, activo, genera_objetivo. Charts/graphs, full calculations, metas_indicadores, objetivos and dashboard deferred. See 9.9 plan/playbook.

--- a/.agents/STAGE-CHECKLISTS.md
+++ b/.agents/STAGE-CHECKLISTS.md
@@ -3646,6 +3646,23 @@ docker compose exec db psql -U qnova -d qnova -c "SELECT COUNT(*) FROM mantenimi
 
 **Branch status:** Stage 9.36 on `feat/stage-9.36-equipos-calendario`.
 
+## Stage 9.37 — Auditorías informes first slice
+
+**Goal:** Edit `conclusiones_informe` / `recomendaciones_informe` (+ lugar/fecha) on ejecución; printable HTML ficha with hallazgos + mejoras; links from ejecución list/form. Patch 0047.
+
+**Validation:**
+```bash
+docker compose exec app php -l Pages/Auditorias/Informe/Formulario.php Pages/Auditorias/Informe/Ficha.php index.php
+# apply 0047 if DB already initialized:
+docker compose exec -T db psql -U qnova -d qnova < docker/db-init/data-patches/0047-auditorias-informes.sql
+docker compose exec app ./scripts/verify-8.6.sh
+docker compose exec db psql -U qnova -d qnova -c "SELECT id, lugar_informe, left(conclusiones_informe,40) FROM auditorias WHERE id=1;"
+```
+
+**Browser:** Ejecución → Informe → edit conclusions → save → ficha ver → Imprimir.
+
+**Branch status:** Stage 9.37 on `feat/stage-9.37-auditorias-informes`.
+
 
 
 

--- a/Pages/Auditorias/Informe/Ficha.php
+++ b/Pages/Auditorias/Informe/Ficha.php
@@ -1,0 +1,162 @@
+<?php
+namespace Tuqan\Pages\Auditorias\Informe;
+
+use Tuqan\Classes\Config;
+use Tuqan\Pages\Catalog\CatalogFormulario;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+/**
+ * Printable informe ficha (Stage 9.37).
+ * HTML + print CSS; GenPDF deferred.
+ */
+class Ficha extends CatalogFormulario
+{
+    protected string $table        = 'auditorias';
+    protected string $title        = 'Ficha de Informe';
+    protected string $templateDir  = 'auditorias/informes';
+    protected string $flashPrefix  = 'informe';
+    protected string $listRoute    = '/admin/auditorias/ejecucion';
+
+    protected function getSelectForForm(): string
+    {
+        return "SELECT id, programa, nombre, fecha, estado, descripcion, observaciones, activo,
+                       requisitos, alcance, interna, fecha_realiza, lugar_informe, fecha_informe,
+                       recomendaciones_informe, conclusiones_informe
+                FROM {$this->table} WHERE id = ?";
+    }
+
+    protected function loadItem($id): ?array
+    {
+        if ($id <= 0) {
+            return null;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada($this->getSelectForForm(), [$id]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row) {
+            return null;
+        }
+
+        return [
+            'id'                      => $row[0],
+            'programa'                => $row[1],
+            'nombre'                  => $row[2],
+            'fecha'                   => $row[3],
+            'estado'                  => $row[4] ?? 0,
+            'descripcion'             => $row[5] ?? null,
+            'observaciones'           => $row[6] ?? null,
+            'activo'                  => $row[7],
+            'requisitos'              => $row[8] ?? null,
+            'alcance'                 => $row[9] ?? null,
+            'interna'                 => $row[10],
+            'fecha_realiza'           => $row[11] ?? null,
+            'lugar_informe'           => $row[12] ?? null,
+            'fecha_informe'           => $row[13] ?? null,
+            'recomendaciones_informe' => $row[14] ?? null,
+            'conclusiones_informe'    => $row[15] ?? null,
+        ];
+    }
+
+    public function ShowPage($id = null)
+    {
+        Config::initialize();
+
+        if ($id === null && isset($_GET['id'])) {
+            $id = (int)$_GET['id'];
+        }
+        $id = (int)$id;
+        if ($id <= 0) {
+            header('Location: ' . $this->listRoute);
+            exit;
+        }
+
+        $item = $this->loadItem($id);
+        if (!$item) {
+            header('Location: ' . $this->listRoute);
+            exit;
+        }
+
+        $item['programa_label'] = $this->getRelatedLabel('programa_auditoria', $item['programa'] ?? null);
+        $item['interna_label'] = $item['interna'] ? 'Interna' : 'Externa';
+
+        $loader = new FilesystemLoader(Config::$template_path);
+        $twig = new Environment($loader, ['cache' => Config::$cache_path]);
+
+        $vars = array_merge($this->getUserContext(), [
+            'sidebarMenu' => $this->getSidebarMenu(),
+            'pageTitle'   => 'Informe — ' . ($item['nombre'] ?? ('Auditoría #' . $id)),
+            'auditoria'   => $item,
+            'hallazgos'   => $this->fetchHallazgos($id),
+            'mejoras'     => $this->fetchMejoras($id),
+            'flash_success' => $_SESSION[$this->flashPrefix . '_flash_success'] ?? null,
+        ]);
+        unset($_SESSION[$this->flashPrefix . '_flash_success']);
+
+        try {
+            return $twig->load($this->templateDir . '/ficha.twig')->render($vars);
+        } catch (\Exception $e) {
+            return 'Error al cargar la ficha de informe: ' . $e->getMessage();
+        }
+    }
+
+    protected function fetchHallazgos(int $auditoriaId): array
+    {
+        try {
+            $db = $this->getDb();
+            $db->consultaPreparada(
+                'SELECT id, fecha, descripcion, tipo, gravedad, cerrado FROM hallazgos_auditoria WHERE auditoria = ? ORDER BY id',
+                [$auditoriaId]
+            );
+            $items = [];
+            while ($row = $db->coger_Fila()) {
+                $items[] = [
+                    'id'          => $row[0],
+                    'fecha'       => $row[1],
+                    'descripcion' => $row[2],
+                    'tipo'        => $row[3],
+                    'gravedad'    => $row[4],
+                    'cerrado'     => $row[5],
+                ];
+            }
+            $db->desconexion();
+            return $items;
+        } catch (\Throwable $e) {
+            return [];
+        }
+    }
+
+    protected function fetchMejoras(int $auditoriaId): array
+    {
+        try {
+            $db = $this->getDb();
+            $db->consultaPreparada(
+                'SELECT id, fecha, descripcion, cerrada, usuario_verifica FROM acciones_mejora WHERE auditoria = ? ORDER BY id',
+                [$auditoriaId]
+            );
+            $items = [];
+            while ($row = $db->coger_Fila()) {
+                $cerrada = $row[3];
+                $verifica = $row[4] ?? null;
+                if ($cerrada) {
+                    $estado = 'Cerrada';
+                } elseif ($verifica) {
+                    $estado = 'Verificada';
+                } else {
+                    $estado = 'Pendiente';
+                }
+                $items[] = [
+                    'id'          => $row[0],
+                    'fecha'       => $row[1],
+                    'descripcion' => $row[2],
+                    'estado'      => $estado,
+                ];
+            }
+            $db->desconexion();
+            return $items;
+        } catch (\Throwable $e) {
+            return [];
+        }
+    }
+}

--- a/Pages/Auditorias/Informe/Formulario.php
+++ b/Pages/Auditorias/Informe/Formulario.php
@@ -1,0 +1,226 @@
+<?php
+namespace Tuqan\Pages\Auditorias\Informe;
+
+use Tuqan\Pages\Catalog\CatalogFormulario;
+
+/**
+ * Auditoría informe editor (Stage 9.37).
+ * Edits lugar/fecha/conclusiones/recomendaciones on existing ejecución row.
+ * Create new auditoría is not in scope — use Ejecución form.
+ */
+class Formulario extends CatalogFormulario
+{
+    protected string $table        = 'auditorias';
+    protected string $title        = 'Informe de Auditoría';
+    protected string $templateDir  = 'auditorias/informes';
+    protected string $flashPrefix  = 'informe';
+    protected string $listRoute    = '/admin/auditorias/ejecucion';
+
+    protected function getSelectForForm(): string
+    {
+        return "SELECT id, programa, nombre, fecha, estado, descripcion, observaciones, activo,
+                       requisitos, alcance, interna, fecha_realiza, lugar_informe, fecha_informe,
+                       recomendaciones_informe, conclusiones_informe
+                FROM {$this->table} WHERE id = ?";
+    }
+
+    protected function loadItem($id): ?array
+    {
+        if ($id <= 0) {
+            return null;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada($this->getSelectForForm(), [$id]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row) {
+            return null;
+        }
+
+        return [
+            'id'                      => $row[0],
+            'programa'                => $row[1],
+            'nombre'                  => $row[2],
+            'fecha'                   => $row[3],
+            'estado'                  => $row[4] ?? 0,
+            'descripcion'             => $row[5] ?? null,
+            'observaciones'           => $row[6] ?? null,
+            'activo'                  => $row[7],
+            'requisitos'              => $row[8] ?? null,
+            'alcance'                 => $row[9] ?? null,
+            'interna'                 => $row[10],
+            'fecha_realiza'           => $row[11] ?? null,
+            'lugar_informe'           => $row[12] ?? null,
+            'fecha_informe'           => $row[13] ?? null,
+            'recomendaciones_informe' => $row[14] ?? null,
+            'conclusiones_informe'    => $row[15] ?? null,
+        ];
+    }
+
+    protected function buildFormVariables(?array $item): array
+    {
+        $vars = parent::buildFormVariables($item);
+        $vars['pageTitle'] = $item
+            ? 'Informe: ' . ($item['nombre'] ?? ('Auditoría #' . $item['id']))
+            : 'Informe de Auditoría';
+
+        $key = strtolower($this->flashPrefix);
+        // Map flash key "informe" to item; also expose as auditoria for templates
+        if ($item) {
+            $item['programa_label'] = $this->getRelatedLabel('programa_auditoria', $item['programa'] ?? null);
+            $vars[$key] = $item;
+            $vars['auditoria'] = $item;
+            $vars['hallazgos_relacionados'] = $this->fetchHallazgos((int)$item['id']);
+            $vars['mejora_relacionadas'] = $this->fetchMejoras((int)$item['id']);
+        } else {
+            $vars['auditoria'] = null;
+            $vars['hallazgos_relacionados'] = [];
+            $vars['mejora_relacionadas'] = [];
+        }
+
+        return $vars;
+    }
+
+    protected function fetchHallazgos(int $auditoriaId): array
+    {
+        try {
+            $db = $this->getDb();
+            $db->consultaPreparada(
+                'SELECT id, fecha, descripcion, tipo, gravedad, cerrado FROM hallazgos_auditoria WHERE auditoria = ? ORDER BY id',
+                [$auditoriaId]
+            );
+            $items = [];
+            while ($row = $db->coger_Fila()) {
+                $items[] = [
+                    'id'          => $row[0],
+                    'fecha'       => $row[1],
+                    'descripcion' => $row[2],
+                    'tipo'        => $row[3],
+                    'gravedad'    => $row[4],
+                    'cerrado'     => $row[5],
+                ];
+            }
+            $db->desconexion();
+            return $items;
+        } catch (\Throwable $e) {
+            return [];
+        }
+    }
+
+    protected function fetchMejoras(int $auditoriaId): array
+    {
+        try {
+            $db = $this->getDb();
+            $db->consultaPreparada(
+                'SELECT id, fecha, descripcion, cerrada, usuario_verifica FROM acciones_mejora WHERE auditoria = ? ORDER BY id',
+                [$auditoriaId]
+            );
+            $items = [];
+            while ($row = $db->coger_Fila()) {
+                $cerrada = $row[3];
+                $verifica = $row[4] ?? null;
+                if ($cerrada) {
+                    $estado = 'Cerrada';
+                } elseif ($verifica) {
+                    $estado = 'Verificada';
+                } else {
+                    $estado = 'Pendiente';
+                }
+                $items[] = [
+                    'id'          => $row[0],
+                    'fecha'       => $row[1],
+                    'descripcion' => $row[2],
+                    'estado'      => $estado,
+                ];
+            }
+            $db->desconexion();
+            return $items;
+        } catch (\Throwable $e) {
+            return [];
+        }
+    }
+
+    protected function getPostData(): array
+    {
+        return [
+            'lugar_informe'           => trim($_POST['lugar_informe'] ?? ''),
+            'fecha_informe'           => trim($_POST['fecha_informe'] ?? ''),
+            'fecha_realiza'           => trim($_POST['fecha_realiza'] ?? ''),
+            'conclusiones_informe'    => trim($_POST['conclusiones_informe'] ?? ''),
+            'recomendaciones_informe' => trim($_POST['recomendaciones_informe'] ?? ''),
+        ];
+    }
+
+    protected function validate(array $data): array
+    {
+        // Informe is edit-only; no nombre required. Soft validation only.
+        return [];
+    }
+
+    protected function persist(array $data, $id)
+    {
+        if ($id <= 0) {
+            return;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada(
+            "UPDATE {$this->table}
+             SET lugar_informe = ?, fecha_informe = ?, fecha_realiza = ?,
+                 conclusiones_informe = ?, recomendaciones_informe = ?
+             WHERE id = ?",
+            [
+                $data['lugar_informe'],
+                $data['fecha_informe'] ?: null,
+                $data['fecha_realiza'] ?: null,
+                $data['conclusiones_informe'],
+                $data['recomendaciones_informe'],
+                $id,
+            ]
+        );
+        $db->desconexion();
+    }
+
+    public function ShowPage($id = null)
+    {
+        if ($id === null && isset($_GET['id'])) {
+            $id = (int)$_GET['id'];
+        }
+        $id = (int)$id;
+        if ($id <= 0) {
+            header('Location: ' . $this->listRoute);
+            exit;
+        }
+        $item = $this->loadItem($id);
+        if (!$item) {
+            $_SESSION[$this->flashPrefix . '_flash_error'] = 'Auditoría no encontrada.';
+            header('Location: ' . $this->listRoute);
+            exit;
+        }
+        return parent::ShowPage($id);
+    }
+
+    public function Procesar($id = null)
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            header('Location: ' . $this->listRoute);
+            exit;
+        }
+
+        if ($id === null) {
+            $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+        }
+        $id = (int)$id;
+        if ($id <= 0 || !$this->loadItem($id)) {
+            $_SESSION[$this->flashPrefix . '_flash_error'] = 'Auditoría no encontrada.';
+            header('Location: ' . $this->listRoute);
+            exit;
+        }
+
+        $data = $this->getPostData();
+        $this->persist($data, $id);
+
+        $_SESSION[$this->flashPrefix . '_flash_success'] = 'Informe actualizado correctamente.';
+        header('Location: /admin/auditorias/informes/ver/' . $id);
+        exit;
+    }
+}

--- a/docker/db-init/data-patches/0047-auditorias-informes.sql
+++ b/docker/db-init/data-patches/0047-auditorias-informes.sql
@@ -1,0 +1,24 @@
+-- 0047-auditorias-informes.sql
+-- Stage 9.37: Informe fields on auditorias (legacy informeauditoria form)
+-- 0031 had lugar_informe + fecha_informe; conclusions/recommendations were missing.
+
+ALTER TABLE auditorias ADD COLUMN IF NOT EXISTS recomendaciones_informe TEXT;
+ALTER TABLE auditorias ADD COLUMN IF NOT EXISTS conclusiones_informe TEXT;
+
+UPDATE auditorias SET
+    lugar_informe = COALESCE(NULLIF(TRIM(lugar_informe), ''), 'Sala de reuniones'),
+    fecha_informe = COALESCE(fecha_informe, CURRENT_DATE),
+    conclusiones_informe = COALESCE(
+        NULLIF(TRIM(conclusiones_informe), ''),
+        'La auditoría se ha realizado según el programa. Se identifican oportunidades de mejora documentadas en hallazgos y acciones de mejora vinculadas.'
+    ),
+    recomendaciones_informe = COALESCE(
+        NULLIF(TRIM(recomendaciones_informe), ''),
+        'Cerrar hallazgos abiertos en plazo. Revisar eficacia de acciones de mejora en la siguiente auditoría de seguimiento.'
+    )
+WHERE id = 1
+  AND EXISTS (SELECT 1 FROM auditorias WHERE id = 1);
+
+INSERT INTO data_patches (filename, applied_at)
+VALUES ('0047-auditorias-informes.sql', NOW())
+ON CONFLICT (filename) DO NOTHING;

--- a/index.php
+++ b/index.php
@@ -457,6 +457,13 @@ $router->addRoute('GET', '/admin/auditorias/horario/editar/{id}', ['Tuqan\Pages\
 $router->addRoute('POST', '/admin/auditorias/horario/nuevo', ['Tuqan\Pages\Auditorias\Horario\Formulario', 'Procesar'], ['before' => 'auth_company']);
 $router->addRoute('POST', '/admin/auditorias/horario/editar/{id}', ['Tuqan\Pages\Auditorias\Horario\Formulario', 'Procesar'], ['before' => 'auth_company']);
 
+// === Auditorías Informes (Stage 9.37 first slice) ===
+$router->addRoute('GET', '/admin/auditorias/informes/editar/{id}', ['Tuqan\Pages\Auditorias\Informe\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/auditorias/informes/editar/{id}', ['Tuqan\Pages\Auditorias\Informe\Formulario', 'Procesar'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/auditorias/informes/ver/{id}', ['Tuqan\Pages\Auditorias\Informe\Ficha', 'ShowPage'], ['before' => 'auth_company']);
+// Legacy menu-ish: auditorias:informeauditoria:formulario:editar
+$router->addRoute('GET', '/administracion/auditorias/informeauditoria/formulario/editar/{id}', ['Tuqan\Pages\Auditorias\Informe\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+
 // === Aspectos Ambientales (Stage 9.7 basic slice) ===
 $router->addRoute('GET', '/admin/aspectos', ['Tuqan\Pages\Aspectos\Listado', 'ShowPage'], ['before' => 'auth_company']);
 $router->addRoute('GET', '/admin/aspectos/nuevo', ['Tuqan\Pages\Aspectos\Formulario', 'ShowPage'], ['before' => 'auth_company']);

--- a/reference/stage-9.37-auditorias-informes-plan.md
+++ b/reference/stage-9.37-auditorias-informes-plan.md
@@ -1,0 +1,22 @@
+# Stage 9.37 — Auditorías informes first slice
+
+**Status**: Planning (plan first)
+**Branch**: `feat/stage-9.37-auditorias-informes`
+**Driver**: Sized next after 9.36 (diversify from Equipos). Legacy `auditorias:informeauditoria` edits lugar/fecha/conclusiones/recomendaciones on `auditorias` and supports print. Modern ejecución already has lugar_informe + fecha_informe; conclusions/recommendations missing from 0031.
+
+## Goals
+1. Patch **0047**: ADD `recomendaciones_informe` + `conclusiones_informe` if missing; demo text on seed auditoría.
+2. `Pages/Auditorias/Informe/{Formulario,Ficha}` — edit informe fields; printable HTML ficha (header + body + hallazgos + mejoras; no GenPDF).
+3. Routes: `/admin/auditorias/informes/editar/{id}`, POST same, `/admin/auditorias/informes/ver/{id}`; legacy path optional.
+4. Links from ejecución list + form (+ Informe / Ver ficha).
+5. verify + playbook + TODOS.
+
+## Out
+- GenPDF binary export, full formal layout, email, multi-format templates.
+
+## Sizing
+- One outcome: edit and view/print audit informe.
+- ~12–15 files, 1 patch.
+
+---
+*Plan committed first. Docker-only.*

--- a/reference/stage-9.37-auditorias-informes-plan.md
+++ b/reference/stage-9.37-auditorias-informes-plan.md
@@ -1,6 +1,6 @@
 # Stage 9.37 — Auditorías informes first slice
 
-**Status**: Planning (plan first)
+**Status**: Implemented (verify + PR)
 **Branch**: `feat/stage-9.37-auditorias-informes`
 **Driver**: Sized next after 9.36 (diversify from Equipos). Legacy `auditorias:informeauditoria` edits lugar/fecha/conclusiones/recomendaciones on `auditorias` and supports print. Modern ejecución already has lugar_informe + fecha_informe; conclusions/recommendations missing from 0031.
 

--- a/scripts/verify-8.6.sh
+++ b/scripts/verify-8.6.sh
@@ -152,6 +152,12 @@ SELECT COUNT(*) AS mantenimientos_current_year FROM mantenimientos
     OR (fecha_realiza IS NOT NULL AND date_part('year', fecha_realiza) = date_part('year', CURRENT_DATE));
 SELECT COUNT(*) AS calendario_demo_rows FROM mantenimientos WHERE comentarios LIKE 'Calendario demo:%';
 
+-- 9.37 Auditorías informes evidence
+SELECT '0047-auditorias-informes.sql' AS patch, COUNT(*) FROM data_patches WHERE filename = '0047-auditorias-informes.sql';
+SELECT COUNT(*) AS auditorias_with_conclusiones FROM auditorias WHERE conclusiones_informe IS NOT NULL AND TRIM(conclusiones_informe) <> '';
+SELECT COUNT(*) AS auditorias_with_recomendaciones FROM auditorias WHERE recomendaciones_informe IS NOT NULL AND TRIM(recomendaciones_informe) <> '';
+SELECT id, lugar_informe, fecha_informe IS NOT NULL AS has_fecha FROM auditorias WHERE id = 1;
+
 -- 9.5 Formación (Planes) + Documentación evidence
 SELECT COUNT(*) AS plan_formacion_rows FROM plan_formacion;
 SELECT COUNT(*) AS documentos_rows FROM documentos;

--- a/templates/auditorias/ejecucion/formulario.twig
+++ b/templates/auditorias/ejecucion/formulario.twig
@@ -8,6 +8,10 @@
         <h2 style="margin: 0; font-size: 20px;">{{ pageTitle }}</h2>
         <div>
             <a href="/admin/auditorias/ejecucion" class="btn btn-default btn-sm">Volver al listado</a>
+            {% if isEdit and auditoria.id %}
+            <a href="/admin/auditorias/informes/editar/{{ auditoria.id }}" class="btn btn-success btn-sm">Informe</a>
+            <a href="/admin/auditorias/informes/ver/{{ auditoria.id }}" class="btn btn-info btn-sm">Ver ficha</a>
+            {% endif %}
         </div>
     </div>
 </div>
@@ -203,7 +207,8 @@
         {% endif %}
 
         <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
-            Auditorías ejecución (9.19–9.35: Mejora, Hallazgos, Horario). Informes deferred.
+            Auditorías ejecución (9.19–9.37). Conclusiones y recomendaciones del informe en
+            <a href="{% if isEdit and auditoria.id %}/admin/auditorias/informes/editar/{{ auditoria.id }}{% else %}/admin/auditorias/ejecucion{% endif %}">Informe</a>.
         </div>
     </form>
 </div>

--- a/templates/auditorias/ejecucion/listado.twig
+++ b/templates/auditorias/ejecucion/listado.twig
@@ -33,7 +33,7 @@
                         <th>Mejora</th>
                         <th>Hallazgos</th>
                         <th>Horario</th>
-                        <th style="width:280px;text-align:right;">Acciones</th>
+                        <th style="width:320px;text-align:right;">Acciones</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -68,6 +68,7 @@
                         </td>
                         <td style="text-align:right; white-space: nowrap;">
                             <a href="/admin/auditorias/ejecucion/editar/{{ a.id }}" class="btn btn-xs btn-default">Editar</a>
+                            <a href="/admin/auditorias/informes/editar/{{ a.id }}" class="btn btn-xs btn-success" title="Informe">Informe</a>
                             <a href="/admin/auditorias/horario/nuevo?auditoria={{ a.id }}" class="btn btn-xs btn-warning" title="Nueva franja">+ Horario</a>
                             <a href="/admin/auditorias/hallazgos/nuevo?auditoria={{ a.id }}" class="btn btn-xs btn-info" title="Nuevo hallazgo">+ Hallazgo</a>
                             <a href="/admin/mejora/nuevo?auditoria={{ a.id }}" class="btn btn-xs btn-primary" title="Crear acción de mejora ligada">+ Mejora</a>
@@ -79,7 +80,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Auditorías ejecución (9.19–9.35: Mejora, Hallazgos, Horario). Informes deferred.
+        Auditorías ejecución (9.19–9.37: Mejora, Hallazgos, Horario, Informes).
     </div>
 </div>
 {% endblock %}

--- a/templates/auditorias/informes/ficha.twig
+++ b/templates/auditorias/informes/ficha.twig
@@ -1,0 +1,155 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}{{ pageTitle }} - Tuqan{% endblock %}
+
+{% block content %}
+<style>
+@media print {
+    .no-print, .page-header .btn, .sidebar, nav, .navbar { display: none !important; }
+    .ficha-print { box-shadow: none !important; border: none !important; }
+    body { background: #fff !important; }
+}
+.ficha-print { background: #fff; border: 1px solid #ddd; border-radius: 4px; padding: 24px 28px; max-width: 900px; }
+.ficha-print h1 { margin-top: 0; font-size: 22px; }
+.ficha-print h2 { font-size: 16px; border-bottom: 1px solid #eee; padding-bottom: 6px; margin-top: 22px; }
+.ficha-meta { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 24px; font-size: 13px; margin-bottom: 8px; }
+.ficha-meta dt { font-weight: 600; color: #555; margin: 0; }
+.ficha-meta dd { margin: 0 0 6px 0; }
+.ficha-body { white-space: pre-wrap; font-size: 14px; line-height: 1.45; }
+</style>
+
+<div class="page-header no-print" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 8px;">
+        <h2 style="margin: 0; font-size: 20px;">{{ pageTitle }}</h2>
+        <div>
+            <a href="/admin/auditorias/ejecucion" class="btn btn-default btn-sm">Ejecución</a>
+            <a href="/admin/auditorias/informes/editar/{{ auditoria.id }}" class="btn btn-default btn-sm">Editar informe</a>
+            <button type="button" class="btn btn-primary btn-sm" onclick="window.print()">
+                <span class="glyphicon glyphicon-print"></span> Imprimir
+            </button>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px;">
+    {% if flash_success %}
+        <div class="alert alert-success no-print">{{ flash_success }}</div>
+    {% endif %}
+
+    <div class="ficha-print">
+        <h1>Informe de Auditoría</h1>
+        <p style="color:#666;margin-top:-8px;">{{ auditoria.nombre }}</p>
+
+        <dl class="ficha-meta">
+            <div>
+                <dt>ID</dt>
+                <dd>{{ auditoria.id }}</dd>
+                <dt>Programa</dt>
+                <dd>{{ auditoria.programa_label ?? auditoria.programa ?? '—' }}</dd>
+                <dt>Tipo</dt>
+                <dd>{{ auditoria.interna_label ?? '—' }}</dd>
+                <dt>Fecha planificada</dt>
+                <dd>{{ auditoria.fecha ?? '—' }}</dd>
+            </div>
+            <div>
+                <dt>Fecha realización</dt>
+                <dd>{{ auditoria.fecha_realiza ?? '—' }}</dd>
+                <dt>Fecha informe</dt>
+                <dd>{{ auditoria.fecha_informe ?? '—' }}</dd>
+                <dt>Lugar</dt>
+                <dd>{{ auditoria.lugar_informe ?? '—' }}</dd>
+                <dt>Estado / activo</dt>
+                <dd>{{ auditoria.estado ?? 0 }} · {% if auditoria.activo %}Activo{% else %}Inactivo{% endif %}</dd>
+            </div>
+        </dl>
+
+        {% if auditoria.descripcion %}
+        <h2>Descripción</h2>
+        <div class="ficha-body">{{ auditoria.descripcion }}</div>
+        {% endif %}
+
+        {% if auditoria.alcance or auditoria.requisitos %}
+        <h2>Alcance y requisitos</h2>
+        {% if auditoria.alcance %}<p><strong>Alcance:</strong></p><div class="ficha-body">{{ auditoria.alcance }}</div>{% endif %}
+        {% if auditoria.requisitos %}<p><strong>Requisitos:</strong></p><div class="ficha-body">{{ auditoria.requisitos }}</div>{% endif %}
+        {% endif %}
+
+        <h2>Conclusiones</h2>
+        {% if auditoria.conclusiones_informe %}
+            <div class="ficha-body">{{ auditoria.conclusiones_informe }}</div>
+        {% else %}
+            <p class="text-muted"><em>Sin conclusiones registradas.</em></p>
+        {% endif %}
+
+        <h2>Recomendaciones</h2>
+        {% if auditoria.recomendaciones_informe %}
+            <div class="ficha-body">{{ auditoria.recomendaciones_informe }}</div>
+        {% else %}
+            <p class="text-muted"><em>Sin recomendaciones registradas.</em></p>
+        {% endif %}
+
+        {% if auditoria.observaciones %}
+        <h2>Observaciones</h2>
+        <div class="ficha-body">{{ auditoria.observaciones }}</div>
+        {% endif %}
+
+        <h2>Hallazgos ({{ hallazgos|length }})</h2>
+        {% if hallazgos is empty %}
+            <p class="text-muted">No hay hallazgos registrados.</p>
+        {% else %}
+            <table class="table table-condensed table-bordered" style="font-size:13px;">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Fecha</th>
+                        <th>Descripción</th>
+                        <th>Tipo</th>
+                        <th>Cerrado</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for h in hallazgos %}
+                    <tr>
+                        <td>{{ h.id }}</td>
+                        <td>{{ h.fecha ?? '—' }}</td>
+                        <td>{{ h.descripcion }}</td>
+                        <td>{{ h.tipo ?? '—' }}</td>
+                        <td>{% if h.cerrado %}Sí{% else %}No{% endif %}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+
+        <h2>Acciones de mejora ({{ mejoras|length }})</h2>
+        {% if mejoras is empty %}
+            <p class="text-muted">No hay acciones de mejora vinculadas.</p>
+        {% else %}
+            <table class="table table-condensed table-bordered" style="font-size:13px;">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Fecha</th>
+                        <th>Descripción</th>
+                        <th>Estado</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for m in mejoras %}
+                    <tr>
+                        <td>{{ m.id }}</td>
+                        <td>{{ m.fecha ?? '—' }}</td>
+                        <td>{{ m.descripcion }}</td>
+                        <td>{{ m.estado }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+
+        <p class="text-muted" style="margin-top:28px;font-size:11px;">
+            Generado desde Tuqan · Stage 9.37 · Ficha HTML (GenPDF deferred)
+        </p>
+    </div>
+</div>
+{% endblock %}

--- a/templates/auditorias/informes/formulario.twig
+++ b/templates/auditorias/informes/formulario.twig
@@ -1,0 +1,117 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}{{ pageTitle }} - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 8px;">
+        <h2 style="margin: 0; font-size: 20px;">{{ pageTitle }}</h2>
+        <div>
+            <a href="/admin/auditorias/ejecucion" class="btn btn-default btn-sm">Ejecución</a>
+            {% if auditoria and auditoria.id %}
+            <a href="/admin/auditorias/ejecucion/editar/{{ auditoria.id }}" class="btn btn-default btn-sm">Editar auditoría</a>
+            <a href="/admin/auditorias/informes/ver/{{ auditoria.id }}" class="btn btn-info btn-sm">Ver ficha</a>
+            {% endif %}
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px; max-width: 820px;">
+    {% if not auditoria %}
+        <div class="alert alert-warning">Auditoría no encontrada. Abra el informe desde el listado de ejecución.</div>
+    {% else %}
+    <p class="text-muted" style="margin-top:0;">
+        Programa: <strong>{{ auditoria.programa_label ?? auditoria.programa ?? '—' }}</strong>
+        · Fecha plan: {{ auditoria.fecha ?? '—' }}
+        · ID {{ auditoria.id }}
+    </p>
+
+    <form method="POST" action="/admin/auditorias/informes/editar/{{ auditoria.id }}">
+        <input type="hidden" name="id" value="{{ auditoria.id }}">
+
+        <div class="row">
+            <div class="col-sm-6">
+                <div class="form-group">
+                    <label for="lugar_informe">Lugar del informe</label>
+                    <input type="text" class="form-control" id="lugar_informe" name="lugar_informe"
+                           value="{{ auditoria.lugar_informe ?? '' }}">
+                </div>
+            </div>
+            <div class="col-sm-3">
+                <div class="form-group">
+                    <label for="fecha_informe">Fecha informe</label>
+                    <input type="date" class="form-control" id="fecha_informe" name="fecha_informe"
+                           value="{{ auditoria.fecha_informe ?? '' }}">
+                </div>
+            </div>
+            <div class="col-sm-3">
+                <div class="form-group">
+                    <label for="fecha_realiza">Fecha realización</label>
+                    <input type="date" class="form-control" id="fecha_realiza" name="fecha_realiza"
+                           value="{{ auditoria.fecha_realiza ?? '' }}">
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label for="conclusiones_informe">Conclusiones</label>
+            <textarea class="form-control" id="conclusiones_informe" name="conclusiones_informe" rows="5">{{ auditoria.conclusiones_informe ?? '' }}</textarea>
+        </div>
+
+        <div class="form-group">
+            <label for="recomendaciones_informe">Recomendaciones</label>
+            <textarea class="form-control" id="recomendaciones_informe" name="recomendaciones_informe" rows="5">{{ auditoria.recomendaciones_informe ?? '' }}</textarea>
+        </div>
+
+        <div class="form-group" style="margin-top: 16px;">
+            <button type="submit" class="btn btn-primary">Guardar informe</button>
+            <a href="/admin/auditorias/informes/ver/{{ auditoria.id }}" class="btn btn-default" style="margin-left:8px;">Cancelar / Ver ficha</a>
+        </div>
+    </form>
+
+    <div style="margin-top: 28px; padding-top: 16px; border-top: 1px solid #eee;">
+        <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px;">
+            <h4 style="margin:0; font-size:16px;">Hallazgos vinculados ({{ hallazgos_relacionados|length }})</h4>
+            <a href="/admin/auditorias/hallazgos?auditoria={{ auditoria.id }}" class="btn btn-default btn-sm">Ver listado</a>
+        </div>
+        {% if hallazgos_relacionados is empty %}
+            <div class="alert alert-info" style="margin-bottom:0;">Sin hallazgos. Aparecerán en la ficha cuando existan.</div>
+        {% else %}
+            <ul class="list-group">
+                {% for h in hallazgos_relacionados %}
+                <li class="list-group-item">
+                    <a href="/admin/auditorias/hallazgos/editar/{{ h.id }}">#{{ h.id }}</a>
+                    — {{ h.descripcion }}
+                    <span class="text-muted">({{ h.tipo ?? '—' }}{% if h.cerrado %}, cerrado{% endif %})</span>
+                </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    </div>
+
+    <div style="margin-top: 20px; padding-top: 16px; border-top: 1px solid #eee;">
+        <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px;">
+            <h4 style="margin:0; font-size:16px;">Acciones de mejora ({{ mejora_relacionadas|length }})</h4>
+            <a href="/admin/mejora?auditoria={{ auditoria.id }}" class="btn btn-default btn-sm">Ver listado</a>
+        </div>
+        {% if mejora_relacionadas is empty %}
+            <div class="alert alert-info" style="margin-bottom:0;">Sin acciones de mejora vinculadas.</div>
+        {% else %}
+            <ul class="list-group">
+                {% for m in mejora_relacionadas %}
+                <li class="list-group-item">
+                    <a href="/admin/mejora/editar/{{ m.id }}">#{{ m.id }}</a>
+                    — {{ m.descripcion }}
+                    <span class="label label-default">{{ m.estado }}</span>
+                </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    </div>
+    {% endif %}
+
+    <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
+        Informe de auditoría (Stage 9.37). Ficha HTML imprimible; GenPDF deferred.
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Patch **0047**: `recomendaciones_informe` + `conclusiones_informe` on `auditorias` + demo on id=1
- Edit informe: `/admin/auditorias/informes/editar/{id}` (lugar, fechas, conclusiones, recomendaciones)
- Printable ficha: `/admin/auditorias/informes/ver/{id}` (HTML + `window.print()`, hallazgos + mejoras)
- Links from ejecución list (**Informe**) and form (Informe / Ver ficha)
- Legacy path alias for informeauditoria edit
- verify + living docs

## Out of scope
- GenPDF binary export / formal multi-format templates

## Test plan
- [ ] Apply 0047 (or clean init-db)
- [ ] `php -l` on Informe classes + index
- [ ] `./scripts/verify-8.6.sh` (0047 asserts)
- [ ] Browser: ejecución → Informe → edit → save → ficha → Imprimir