### PR TITLE
feat(9.38): Equipos plan mantenimiento / auto-preventivo

### DIFF
--- a/.agents/MIGRATION-TODOS.md
+++ b/.agents/MIGRATION-TODOS.md
@@ -5,7 +5,7 @@ MIGRATION-PLAN.md = architecture, constraints, high-level stages + history.
 STAGE-CHECKLISTS.md = detailed per-leg playbooks, exact commands, evidence, retrospective lessons.  
 **This file** = scannable "what is left, how big is it, what should the next PR be?" + handoff package for other agents.
 
-**Last updated**: Stage 9.37 on `feat/stage-9.37-auditorias-informes` (Auditorías informes shell). Previous: 9.36 Equipos calendario.
+**Last updated**: Stage 9.38 on `feat/stage-9.38-equipos-plan-preventivo` (Equipos plan / auto-preventivo). Previous: 9.37 Auditorías informes.
 
 ---
 
@@ -106,10 +106,11 @@ Pick 1-2 related items that together form a reviewable PR. Update this list when
 - [x] **Auditorías plan/horario first slice**: Delivered in Stage 9.35 (`horario_auditoria` + modern auditoria FK, list/form, filter/prefill, ejecución reverse links, patch 0045). See 9.35 plan and STAGE-CHECKLISTS.
 - [x] **Equipos calendario first slice**: Delivered in Stage 9.36 (annual calendar over `mantenimientos`, year/equipo filters, tipo markers, links to revisiones, demo patch 0046). See 9.36 plan and STAGE-CHECKLISTS.
 - [x] **Auditorías informes first slice**: Delivered in Stage 9.37 (conclusiones/recomendaciones columns, informe edit + printable HTML ficha, links from ejecución, patch 0047). See 9.37 plan and STAGE-CHECKLISTS.
+- [x] **Equipos plan / auto-preventivo first slice**: Delivered in Stage 9.38 (interval fields on form, plan view, programar preventivo from mantenimiento_cada/dias, patch 0048). See 9.38 plan and STAGE-CHECKLISTS.
 - [ ] **Next** (sized picks):  
-  - Equipos plan mantenimiento / auto-preventivo · In: plan from mantenimiento_cada · Out: full workflows · ~12 files · patch? maybe  
-  - Documentación rich content / binario · In: richer content editor shell · Out: full GenPDF · ~15 files · patch? maybe  
-  - Auditorías GenPDF / formal export · In: PDF from ficha · Out: full GenPDF suite · ~10 files · patch? no
+  - Documentación rich content / binario · In: metadata + optional file shell · Out: full GenPDF · ~15 files · patch? maybe  
+  - Auditorías GenPDF / formal export · In: PDF from ficha · Out: full GenPDF suite · ~10 files · patch? no  
+  - Proveedores homologación · In: evaluation shell · Out: full supplier workflow · ~12 files · patch? maybe
 
 Aim for a mix: one "close the small gaps" + one "new vertical" per couple of legs. Keep delivering working, reviewable increments.
 
@@ -142,8 +143,8 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 - [ ] Homologacion / evaluation flows (common in ISO supplier management).
 
 ### Equipos (Equipment / Assets)
-- [x] Equipos (legacy 70) — basic listado + form (core fields: numero, descripcion, modelo, ubicacion, activo + supporting) in Stage 9.3. Revisiones shell (`mantenimientos` CRUD + links) in Stage 9.33. Calendario anual shell in Stage 9.36. (See 9.3 + 9.33 + 9.36 plans.)
-- [ ] Plan mantenimiento / auto-preventivo from `mantenimiento_cada` + deeper workflows (tie to Auditorias / Mejora).
+- [x] Equipos (legacy 70) — basic listado + form (core fields: numero, descripcion, modelo, ubicacion, activo + supporting) in Stage 9.3. Revisiones shell (`mantenimientos` CRUD + links) in Stage 9.33. Calendario anual shell in Stage 9.36. Plan + auto-preventivo from `mantenimiento_cada`/`dias` in Stage 9.38. (See 9.3 + 9.33 + 9.36 + 9.38 plans.)
+- [ ] Batch reminders / ICS / deeper correctivo + ties to Auditorias / Mejora.
 
 ### Documentación (Core ISO — high value, likely larger)
 - [x] Documentación initial shell delivered in Stage 9.5. Tree in 9.12. Editor/perfiles in 9.23, workflows fields in 9.24, content editor (texto) in 9.26. Estado labels + list filter in 9.31. Quick Revisar/Aprobar transitions in 9.34. Full rich editor, binario, more, PDF deferred. See 9.5 + 9.12 + 9.23 + 9.24 + 9.26 + 9.31 + 9.34 plans.

--- a/.agents/STAGE-CHECKLISTS.md
+++ b/.agents/STAGE-CHECKLISTS.md
@@ -3663,6 +3663,22 @@ docker compose exec db psql -U qnova -d qnova -c "SELECT id, lugar_informe, left
 
 **Branch status:** Stage 9.37 on `feat/stage-9.37-auditorias-informes`.
 
+## Stage 9.38 — Equipos plan mantenimiento / auto-preventivo
+
+**Goal:** Edit `mantenimiento_cada` + días/meses on equipo form; plan page shows next due + history; POST programar preventivo inserts `mantenimientos` row. Patch 0048 demo.
+
+**Validation:**
+```bash
+docker compose exec app php -l Pages/Equipos/Plan.php Pages/Equipos/Formulario.php index.php
+docker compose exec -T db psql -U qnova -d qnova < docker/db-init/data-patches/0048-equipos-plan-preventivo.sql
+docker compose exec app ./scripts/verify-8.6.sh
+docker compose exec db psql -U qnova -d qnova -c "SELECT id, mantenimiento_cada, dias FROM equipos WHERE id IN (1,2);"
+```
+
+**Browser:** `/admin/equipos` → Plan → check next due → Programar preventivo → appears in historial + calendario.
+
+**Branch status:** Stage 9.38 on `feat/stage-9.38-equipos-plan-preventivo`.
+
 
 
 

--- a/Pages/Equipos/Formulario.php
+++ b/Pages/Equipos/Formulario.php
@@ -51,20 +51,24 @@ class Formulario extends CatalogFormulario
             );
 
             $db->consultaPreparada(
-                "SELECT id, numero, descripcion, numero_serie, modelo, fabricante, ubicacion, activo FROM {$this->table} WHERE id = ?",
+                "SELECT id, numero, descripcion, numero_serie, modelo, fabricante, ubicacion, activo, mantenimiento_cada, dias FROM {$this->table} WHERE id = ?",
                 [$id]
             );
             $row = $db->coger_Fila();
             if ($row) {
+                $dias = $row[9] ?? false;
+                $isDays = ($dias === true || $dias === 't' || $dias === '1' || $dias === 1);
                 $item = [
-                    'id'            => $row[0],
-                    'numero'        => $row[1],
-                    'descripcion'   => $row[2],
-                    'numero_serie'  => $row[3] ?? null,
-                    'modelo'        => $row[4] ?? null,
-                    'fabricante'    => $row[5] ?? null,
-                    'ubicacion'     => $row[6] ?? null,
-                    'activo'        => $row[7],
+                    'id'                 => $row[0],
+                    'numero'             => $row[1],
+                    'descripcion'        => $row[2],
+                    'numero_serie'       => $row[3] ?? null,
+                    'modelo'             => $row[4] ?? null,
+                    'fabricante'         => $row[5] ?? null,
+                    'ubicacion'          => $row[6] ?? null,
+                    'activo'             => $row[7],
+                    'mantenimiento_cada' => $row[8] ?? 90,
+                    'dias'               => $isDays,
                 ];
             }
             $db->desconexion();
@@ -111,6 +115,15 @@ class Formulario extends CatalogFormulario
         $fabricante    = trim($_POST['fabricante'] ?? '');
         $ubicacion     = trim($_POST['ubicacion'] ?? '');
         $activo        = !empty($_POST['activo']) ? 1 : 0;
+        // 9.38: plan interval (legacy mantenimiento_cada + dias)
+        $mantenimiento_cada = isset($_POST['mantenimiento_cada']) ? (int)$_POST['mantenimiento_cada'] : 90;
+        if ($mantenimiento_cada < 1) {
+            $mantenimiento_cada = 1;
+        }
+        if ($mantenimiento_cada > 9999) {
+            $mantenimiento_cada = 9999;
+        }
+        $dias = !empty($_POST['dias']) ? 1 : 0; // 1 = días, 0 = meses
 
         $errors = [];
         if ($numero === '') {
@@ -143,15 +156,14 @@ class Formulario extends CatalogFormulario
 
         if ($id > 0) {
             $db->consultaPreparada(
-                "UPDATE {$this->table} SET numero = ?, descripcion = ?, numero_serie = ?, modelo = ?, fabricante = ?, ubicacion = ?, activo = ? WHERE id = ?",
-                [$numero, $descripcion, $numero_serie, $modelo, $fabricante, $ubicacion, $activo, $id]
+                "UPDATE {$this->table} SET numero = ?, descripcion = ?, numero_serie = ?, modelo = ?, fabricante = ?, ubicacion = ?, activo = ?, mantenimiento_cada = ?, dias = ? WHERE id = ?",
+                [$numero, $descripcion, $numero_serie, $modelo, $fabricante, $ubicacion, $activo, $mantenimiento_cada, $dias, $id]
             );
             $msg = "{$this->title} actualizado correctamente.";
         } else {
-            // Supply defaults for maintenance columns not exposed in this first-slice form
             $db->consultaPreparada(
-                "INSERT INTO {$this->table} (numero, descripcion, numero_serie, modelo, fabricante, ubicacion, ver_interna, mantenimiento_cada, dias, activo) VALUES (?, ?, ?, ?, ?, ?, false, 90, false, ?)",
-                [$numero, $descripcion, $numero_serie, $modelo, $fabricante, $ubicacion, $activo]
+                "INSERT INTO {$this->table} (numero, descripcion, numero_serie, modelo, fabricante, ubicacion, ver_interna, mantenimiento_cada, dias, activo) VALUES (?, ?, ?, ?, ?, ?, false, ?, ?, ?)",
+                [$numero, $descripcion, $numero_serie, $modelo, $fabricante, $ubicacion, $mantenimiento_cada, $dias, $activo]
             );
             $msg = "{$this->title} creado correctamente.";
         }

--- a/Pages/Equipos/Plan.php
+++ b/Pages/Equipos/Plan.php
@@ -1,0 +1,238 @@
+<?php
+namespace Tuqan\Pages\Equipos;
+
+use Tuqan\Classes\Config;
+use Tuqan\Pages\Catalog\CatalogListado;
+use Tuqan\Pages\Equipos\Revisiones\Listado as RevisionesListado;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+/**
+ * Plan de mantenimiento per equipo (Stage 9.38).
+ * Shows interval, next preventivo due, history; can program next preventivo.
+ */
+class Plan extends CatalogListado
+{
+    protected string $table       = 'mantenimientos';
+    protected string $title       = 'Plan de Mantenimiento';
+    protected string $templateDir = 'equipos';
+    protected string $flashPrefix = 'plan';
+
+    protected function getSelectSql(): string
+    {
+        return "SELECT id, equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos FROM {$this->table} ORDER BY id";
+    }
+
+    protected function mapRow($row): array
+    {
+        return [
+            'id'             => $row[0],
+            'equipo'         => $row[1] ?? null,
+            'tipo'           => $row[2] ?? null,
+            'fecha_prevista' => $row[3] ?? null,
+            'fecha_realiza'  => $row[4] ?? null,
+            'comentarios'    => $row[5] ?? '',
+            'motivos'        => $row[6] ?? '',
+        ];
+    }
+
+    /**
+     * Load equipo core + maintenance interval.
+     */
+    protected function loadEquipo(int $id): ?array
+    {
+        if ($id <= 0) {
+            return null;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada(
+            'SELECT id, numero, descripcion, modelo, ubicacion, activo, mantenimiento_cada, dias, ver_interna
+             FROM equipos WHERE id = ?',
+            [$id]
+        );
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row) {
+            return null;
+        }
+        $dias = $row[7];
+        $isDays = ($dias === true || $dias === 't' || $dias === '1' || $dias === 1);
+        return [
+            'id'                 => $row[0],
+            'numero'             => $row[1],
+            'descripcion'        => $row[2],
+            'modelo'             => $row[3] ?? null,
+            'ubicacion'          => $row[4] ?? null,
+            'activo'             => $row[5],
+            'mantenimiento_cada' => (int)$row[6],
+            'dias'               => $isDays,
+            'dias_label'         => $isDays ? 'días' : 'meses',
+            'ver_interna'        => $row[8],
+            'label'              => $row[1] . ' — ' . $row[2],
+        ];
+    }
+
+    protected function fetchHistorial(int $equipoId): array
+    {
+        $db = $this->getDb();
+        $db->consultaPreparada(
+            "SELECT id, equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos
+             FROM mantenimientos WHERE equipo = ? ORDER BY COALESCE(fecha_realiza, fecha_prevista) DESC NULLS LAST, id DESC",
+            [$equipoId]
+        );
+        $items = [];
+        while ($row = $db->coger_Fila()) {
+            $item = $this->mapRow($row);
+            $item['tipo_label'] = RevisionesListado::tipoLabel($item['tipo'] ?? null);
+            $items[] = $item;
+        }
+        $db->desconexion();
+        return $items;
+    }
+
+    /**
+     * Last completed/realized preventivo date (fecha_realiza).
+     */
+    protected function lastPreventivoRealiza(int $equipoId): ?string
+    {
+        $db = $this->getDb();
+        $db->consultaPreparada(
+            "SELECT max(fecha_realiza) FROM mantenimientos WHERE equipo = ? AND tipo = 'preventivo' AND fecha_realiza IS NOT NULL",
+            [$equipoId]
+        );
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row || empty($row[0])) {
+            return null;
+        }
+        return substr((string)$row[0], 0, 10);
+    }
+
+    /**
+     * Next due date using legacy rules: base = last preventivo realiza (or today),
+     * add mantenimiento_cada days if dias=true else months.
+     */
+    public static function computeNextDue(string $baseYmd, int $cada, bool $isDays): string
+    {
+        $cada = max(1, $cada);
+        try {
+            $dt = new \DateTimeImmutable($baseYmd);
+        } catch (\Exception $e) {
+            $dt = new \DateTimeImmutable('today');
+        }
+        if ($isDays) {
+            $next = $dt->modify('+' . $cada . ' days');
+        } else {
+            $next = $dt->modify('+' . $cada . ' months');
+        }
+        return $next->format('Y-m-d');
+    }
+
+    protected function resolveNextDue(array $equipo): array
+    {
+        $last = $this->lastPreventivoRealiza((int)$equipo['id']);
+        $base = $last ?: date('Y-m-d');
+        $from = $last ? 'último preventivo realizado' : 'hoy (sin preventivo previo)';
+        $next = self::computeNextDue(
+            $base,
+            (int)$equipo['mantenimiento_cada'],
+            (bool)$equipo['dias']
+        );
+        return [
+            'last_preventivo' => $last,
+            'base_date'       => $base,
+            'base_label'      => $from,
+            'next_due'        => $next,
+        ];
+    }
+
+    public function ShowPage($id = null)
+    {
+        Config::initialize();
+
+        if ($id === null && isset($_GET['id'])) {
+            $id = (int)$_GET['id'];
+        }
+        // Also accept ?equipo= for consistency with other modules
+        if (($id === null || (int)$id <= 0) && isset($_GET['equipo'])) {
+            $id = (int)$_GET['equipo'];
+        }
+        $id = (int)$id;
+        if ($id <= 0) {
+            header('Location: /admin/equipos');
+            exit;
+        }
+
+        $equipo = $this->loadEquipo($id);
+        if (!$equipo) {
+            $_SESSION[$this->flashPrefix . '_flash_error'] = 'Equipo no encontrado.';
+            header('Location: /admin/equipos');
+            exit;
+        }
+
+        $due = $this->resolveNextDue($equipo);
+        $historial = $this->fetchHistorial($id);
+
+        $loader = new FilesystemLoader(Config::$template_path);
+        $twig = new Environment($loader, ['cache' => Config::$cache_path]);
+
+        $vars = array_merge($this->buildCommonVariables(), [
+            'pageTitle'      => 'Plan: ' . $equipo['label'],
+            'equipo'         => $equipo,
+            'due'            => $due,
+            'historial'      => $historial,
+            'flash_success'  => $_SESSION[$this->flashPrefix . '_flash_success'] ?? null,
+            'flash_error'    => $_SESSION[$this->flashPrefix . '_flash_error'] ?? null,
+        ]);
+        unset($_SESSION[$this->flashPrefix . '_flash_success'], $_SESSION[$this->flashPrefix . '_flash_error']);
+
+        try {
+            return $twig->load($this->templateDir . '/plan.twig')->render($vars);
+        } catch (\Exception $e) {
+            return 'Error al cargar el plan de mantenimiento: ' . $e->getMessage();
+        }
+    }
+
+    /**
+     * Create next preventivo mantenimiento row for the equipo.
+     */
+    public function ProgramarPreventivo($id = null)
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            header('Location: /admin/equipos');
+            exit;
+        }
+        Config::initialize();
+
+        if ($id === null) {
+            $id = (int)($_POST['id'] ?? $_POST['equipo'] ?? 0);
+        }
+        $id = (int)$id;
+        $equipo = $this->loadEquipo($id);
+        if (!$equipo) {
+            $_SESSION[$this->flashPrefix . '_flash_error'] = 'Equipo no encontrado.';
+            header('Location: /admin/equipos');
+            exit;
+        }
+
+        $due = $this->resolveNextDue($equipo);
+        $fecha = $due['next_due'];
+        $comentarios = 'Preventivo programado automáticamente (cada '
+            . $equipo['mantenimiento_cada'] . ' ' . $equipo['dias_label'] . ')';
+        $motivos = 'Plan de mantenimiento (Stage 9.38)';
+
+        $db = $this->getDb();
+        // fecha_realiza NOT NULL in legacy schema — set equal to prevista for scheduled rows
+        $db->consultaPreparada(
+            "INSERT INTO mantenimientos (equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos)
+             VALUES (?, 'preventivo', ?, ?, ?, ?)",
+            [$id, $fecha, $fecha, $comentarios, $motivos]
+        );
+        $db->desconexion();
+
+        $_SESSION[$this->flashPrefix . '_flash_success'] =
+            'Preventivo programado para el ' . $fecha . '.';
+        header('Location: /admin/equipos/plan/' . $id);
+        exit;
+    }
+}

--- a/docker/db-init/data-patches/0048-equipos-plan-preventivo.sql
+++ b/docker/db-init/data-patches/0048-equipos-plan-preventivo.sql
@@ -1,0 +1,28 @@
+-- 0048-equipos-plan-preventivo.sql
+-- Stage 9.38: Ensure demo equipos have clear intervals + a past preventivo
+-- so Plan "next due" calculation is visible after init.
+
+-- EQ-001: every 90 days; seed a preventivo ~90 days before "today" if missing
+UPDATE equipos
+SET mantenimiento_cada = 90, dias = true
+WHERE id = 1 AND EXISTS (SELECT 1 FROM equipos WHERE id = 1);
+
+UPDATE equipos
+SET mantenimiento_cada = 6, dias = false
+WHERE id = 2 AND EXISTS (SELECT 1 FROM equipos WHERE id = 2);
+
+INSERT INTO mantenimientos (equipo, tipo, fecha_prevista, fecha_realiza, comentarios, motivos)
+SELECT 1, 'preventivo',
+       (CURRENT_DATE - INTERVAL '90 days')::date,
+       (CURRENT_DATE - INTERVAL '90 days')::date,
+       'Plan demo: preventivo base para cálculo de próximo',
+       'Seed 9.38'
+WHERE EXISTS (SELECT 1 FROM equipos WHERE id = 1)
+  AND NOT EXISTS (
+    SELECT 1 FROM mantenimientos
+    WHERE equipo = 1 AND comentarios = 'Plan demo: preventivo base para cálculo de próximo'
+  );
+
+INSERT INTO data_patches (filename, applied_at)
+VALUES ('0048-equipos-plan-preventivo.sql', NOW())
+ON CONFLICT (filename) DO NOTHING;

--- a/index.php
+++ b/index.php
@@ -354,6 +354,12 @@ $router->addRoute('GET', '/admin/equipos/calendario', ['Tuqan\Pages\Equipos\Cale
 // Legacy menu: equipos:calendario:listado:ver
 $router->addRoute('GET', '/administracion/equipos/calendario/listado/ver', ['Tuqan\Pages\Equipos\Calendario', 'ShowPage'], ['before' => 'auth_company']);
 
+// === Equipos Plan mantenimiento / auto-preventivo (Stage 9.38) ===
+$router->addRoute('GET', '/admin/equipos/plan/{id}', ['Tuqan\Pages\Equipos\Plan', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/equipos/plan/{id}/programar-preventivo', ['Tuqan\Pages\Equipos\Plan', 'ProgramarPreventivo'], ['before' => 'auth_company']);
+// Legacy: equipos:planmantenimiento:listado:ver:fila (id via query when used from modern nav)
+$router->addRoute('GET', '/administracion/equipos/planmantenimiento/listado/ver/{id}', ['Tuqan\Pages\Equipos\Plan', 'ShowPage'], ['before' => 'auth_company']);
+
 // === Mejora / Acciones de Mejora (Stage 9.4) ===
 $router->addRoute('GET', '/admin/mejora', ['Tuqan\Pages\Mejora\Listado', 'ShowPage'], ['before' => 'auth_company']);
 $router->addRoute('GET', '/admin/mejora/nuevo', ['Tuqan\Pages\Mejora\Formulario', 'ShowPage'], ['before' => 'auth_company']);

--- a/reference/stage-9.38-equipos-plan-preventivo-plan.md
+++ b/reference/stage-9.38-equipos-plan-preventivo-plan.md
@@ -1,0 +1,24 @@
+# Stage 9.38 — Equipos plan mantenimiento / auto-preventivo first slice
+
+**Status**: Planning (plan first)
+**Branch**: `feat/stage-9.38-equipos-plan-preventivo`
+**Driver**: Sized next after 9.37. Legacy plan mantenimiento shows equipo maintenance history and offers Mant. Preventivo (next date from `mantenimiento_cada` + `dias`) / Correctivo. Modern has revisiones + calendario; interval fields not on form; no "program next preventivo".
+
+## Goals
+1. Expose `mantenimiento_cada` + `dias` (días/meses) on equipos form (create/edit).
+2. `Pages/Equipos/Plan.php` — plan view per equipo: interval summary, next due (computed), list of mantenimientos, actions.
+3. POST **Programar preventivo**: insert `mantenimientos` tipo=preventivo with fecha_prevista = next due (legacy interval rules).
+4. Quick link to nueva revisión correctivo (existing form prefilled).
+5. Routes `/admin/equipos/plan/{id}`; nav from list/form/calendario/revisiones.
+6. Patch **0048** demo (ensure intervals + one past preventivo for due calc) if useful.
+7. verify + playbook + TODOS.
+
+## Out
+- Full auto-batch for all equipos, email reminders, ICS, deep correctivo workflows.
+
+## Sizing
+- One outcome: see plan + schedule next preventivo for an equipo.
+- ~12–15 files, 0–1 patch.
+
+---
+*Plan committed first. Docker-only.*

--- a/reference/stage-9.38-equipos-plan-preventivo-plan.md
+++ b/reference/stage-9.38-equipos-plan-preventivo-plan.md
@@ -1,6 +1,6 @@
 # Stage 9.38 — Equipos plan mantenimiento / auto-preventivo first slice
 
-**Status**: Planning (plan first)
+**Status**: Implemented (verify + PR)
 **Branch**: `feat/stage-9.38-equipos-plan-preventivo`
 **Driver**: Sized next after 9.37. Legacy plan mantenimiento shows equipo maintenance history and offers Mant. Preventivo (next date from `mantenimiento_cada` + `dias`) / Correctivo. Modern has revisiones + calendario; interval fields not on form; no "program next preventivo".
 

--- a/scripts/verify-8.6.sh
+++ b/scripts/verify-8.6.sh
@@ -158,6 +158,12 @@ SELECT COUNT(*) AS auditorias_with_conclusiones FROM auditorias WHERE conclusion
 SELECT COUNT(*) AS auditorias_with_recomendaciones FROM auditorias WHERE recomendaciones_informe IS NOT NULL AND TRIM(recomendaciones_informe) <> '';
 SELECT id, lugar_informe, fecha_informe IS NOT NULL AS has_fecha FROM auditorias WHERE id = 1;
 
+-- 9.38 Equipos plan preventivo evidence
+SELECT '0048-equipos-plan-preventivo.sql' AS patch, COUNT(*) FROM data_patches WHERE filename = '0048-equipos-plan-preventivo.sql';
+SELECT id, mantenimiento_cada, dias FROM equipos WHERE id IN (1, 2) ORDER BY id;
+SELECT COUNT(*) AS preventivos_equipo1 FROM mantenimientos WHERE equipo = 1 AND tipo = 'preventivo';
+SELECT COUNT(*) AS plan_demo_rows FROM mantenimientos WHERE comentarios LIKE 'Plan demo:%';
+
 -- 9.5 Formación (Planes) + Documentación evidence
 SELECT COUNT(*) AS plan_formacion_rows FROM plan_formacion;
 SELECT COUNT(*) AS documentos_rows FROM documentos;

--- a/templates/equipos/formulario.twig
+++ b/templates/equipos/formulario.twig
@@ -64,6 +64,37 @@
             </div>
         </div>
 
+        <fieldset style="margin-top: 18px; padding-top: 12px; border-top: 1px solid #eee;">
+            <legend style="font-size: 14px; border:0; margin-bottom: 10px;">Plan de mantenimiento</legend>
+            <div class="row">
+                <div class="col-sm-6">
+                    <div class="form-group">
+                        <label for="mantenimiento_cada">Mantenimiento cada</label>
+                        <input type="number" class="form-control" id="mantenimiento_cada" name="mantenimiento_cada"
+                               min="1" max="9999"
+                               value="{{ equipo.mantenimiento_cada ?? 90 }}">
+                    </div>
+                </div>
+                <div class="col-sm-6">
+                    <div class="form-group">
+                        <label>Unidad</label>
+                        <div class="checkbox" style="margin-top: 8px;">
+                            <label>
+                                <input type="checkbox" name="dias" value="1"
+                                       {% if not isEdit or equipo.dias %}checked{% endif %}>
+                                En <strong>días</strong> (desmarcar = meses)
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {% if isEdit and equipo.id %}
+            <p style="margin:0;">
+                <a href="/admin/equipos/plan/{{ equipo.id }}" class="btn btn-default btn-sm">Ver plan / programar preventivo</a>
+            </p>
+            {% endif %}
+        </fieldset>
+
         <div class="form-group" style="margin-top: 20px;">
             <button type="submit" class="btn btn-primary">
                 {{ isEdit ? 'Guardar cambios' : 'Crear Equipo' }}
@@ -72,7 +103,7 @@
         </div>
 
         <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
-            Equipos (Stage 9.3). Los campos de mantenimiento (verificación interna, periodicidad, etc.) y los flujos de revisiones/calendario se añadirán en legs posteriores.
+            Equipos (9.3 + 9.38 plan). Periodicidad alimenta el cálculo de próximo preventivo en el plan.
         </div>
     </form>
 </div>

--- a/templates/equipos/listado.twig
+++ b/templates/equipos/listado.twig
@@ -9,6 +9,7 @@
         <div>
             <a href="/admin/equipos/revisiones" class="btn btn-default btn-sm">Revisiones</a>
             <a href="/admin/equipos/calendario" class="btn btn-default btn-sm">Calendario</a>
+
             <a href="/admin/equipos/nuevo" class="btn btn-primary btn-sm">
                 <span class="glyphicon glyphicon-plus"></span> Nuevo Equipo
             </a>
@@ -52,6 +53,7 @@
                         <td>{% if e.activo %}<span class="label label-success">Activo</span>{% else %}<span class="label label-default">Inactivo</span>{% endif %}</td>
                         <td style="text-align:right; white-space: nowrap;">
                             <a href="/admin/equipos/editar/{{ e.id }}" class="btn btn-xs btn-default">Editar</a>
+                            <a href="/admin/equipos/plan/{{ e.id }}" class="btn btn-xs btn-success" title="Plan de mantenimiento">Plan</a>
                             <a href="/admin/equipos/revisiones/nuevo?equipo={{ e.id }}" class="btn btn-xs btn-primary" title="Nueva revisión">+ Revisión</a>
                         </td>
                     </tr>
@@ -61,7 +63,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Equipos (9.3 + 9.33 revisiones + 9.36 calendario). Auto-plan preventivo deferred.
+        Equipos (9.3 + 9.33 revisiones + 9.36 calendario + 9.38 plan preventivo).
     </div>
 </div>
 {% endblock %}

--- a/templates/equipos/plan.twig
+++ b/templates/equipos/plan.twig
@@ -1,0 +1,115 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}{{ pageTitle }} - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 8px;">
+        <h2 style="margin: 0; font-size: 20px;">{{ pageTitle }}</h2>
+        <div>
+            <a href="/admin/equipos" class="btn btn-default btn-sm">Equipos</a>
+            <a href="/admin/equipos/editar/{{ equipo.id }}" class="btn btn-default btn-sm">Editar equipo</a>
+            <a href="/admin/equipos/calendario?equipo={{ equipo.id }}" class="btn btn-default btn-sm">Calendario</a>
+            <a href="/admin/equipos/revisiones?equipo={{ equipo.id }}" class="btn btn-default btn-sm">Revisiones</a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px; max-width: 960px;">
+    {% if flash_success %}
+        <div class="alert alert-success">{{ flash_success }}</div>
+    {% endif %}
+    {% if flash_error %}
+        <div class="alert alert-danger">{{ flash_error }}</div>
+    {% endif %}
+
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>Periodicidad</strong></div>
+        <div class="panel-body">
+            <div class="row">
+                <div class="col-sm-6">
+                    <p style="margin:0 0 6px;">
+                        <span class="text-muted">Equipo:</span>
+                        <strong>{{ equipo.numero }}</strong> — {{ equipo.descripcion }}
+                    </p>
+                    <p style="margin:0 0 6px;">
+                        <span class="text-muted">Ubicación / modelo:</span>
+                        {{ equipo.ubicacion ?? '—' }} · {{ equipo.modelo ?? '—' }}
+                    </p>
+                    <p style="margin:0;">
+                        <span class="text-muted">Estado:</span>
+                        {% if equipo.activo %}<span class="label label-success">Activo</span>{% else %}<span class="label label-default">Inactivo</span>{% endif %}
+                    </p>
+                </div>
+                <div class="col-sm-6">
+                    <p style="margin:0 0 6px;">
+                        <span class="text-muted">Mantenimiento cada:</span>
+                        <strong>{{ equipo.mantenimiento_cada }} {{ equipo.dias_label }}</strong>
+                        <a href="/admin/equipos/editar/{{ equipo.id }}" class="btn btn-link btn-xs">cambiar</a>
+                    </p>
+                    <p style="margin:0 0 6px;">
+                        <span class="text-muted">Último preventivo realizado:</span>
+                        {{ due.last_preventivo ?? '—' }}
+                    </p>
+                    <p style="margin:0;">
+                        <span class="text-muted">Próximo preventivo (calc.):</span>
+                        <strong class="text-primary">{{ due.next_due }}</strong>
+                        <span class="text-muted" style="font-size:12px;">(desde {{ due.base_label }})</span>
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="panel-footer" style="display:flex; flex-wrap:wrap; gap:8px; align-items:center;">
+            <form method="POST" action="/admin/equipos/plan/{{ equipo.id }}/programar-preventivo" style="display:inline;margin:0;">
+                <input type="hidden" name="id" value="{{ equipo.id }}">
+                <button type="submit" class="btn btn-primary btn-sm"
+                        onclick="return confirm('¿Programar preventivo para {{ due.next_due }}?');">
+                    Programar preventivo ({{ due.next_due }})
+                </button>
+            </form>
+            <a href="/admin/equipos/revisiones/nuevo?equipo={{ equipo.id }}" class="btn btn-warning btn-sm">
+                + Correctivo / revisión manual
+            </a>
+        </div>
+    </div>
+
+    <h3 style="font-size:16px;margin-top:24px;">Historial de mantenimientos</h3>
+    {% if historial is empty %}
+        <div class="alert alert-info">No hay registros de mantenimiento para este equipo.</div>
+    {% else %}
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Tipo</th>
+                        <th>Prevista</th>
+                        <th>Realizada</th>
+                        <th>Comentarios</th>
+                        <th style="width:90px;text-align:right;">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for r in historial %}
+                    <tr>
+                        <td>{{ r.id }}</td>
+                        <td>{{ r.tipo_label ?? r.tipo ?? '—' }}</td>
+                        <td>{{ r.fecha_prevista ?? '—' }}</td>
+                        <td>{{ r.fecha_realiza ?? '—' }}</td>
+                        <td>{{ r.comentarios }}</td>
+                        <td style="text-align:right;">
+                            <a href="/admin/equipos/revisiones/editar/{{ r.id }}" class="btn btn-xs btn-default">Editar</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+
+    <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
+        Plan de mantenimiento (Stage 9.38). Intervalo = <code>mantenimiento_cada</code> + unidad días/meses.
+        Programar preventivo crea una fila en <code>mantenimientos</code>. Recordatorios masivos / ICS deferred.
+    </div>
+</div>
+{% endblock %}

--- a/templates/equipos/revisiones/listado.twig
+++ b/templates/equipos/revisiones/listado.twig
@@ -8,6 +8,9 @@
         <h2 style="margin: 0; font-size: 20px;">Revisiones de Equipos</h2>
         <div>
             <a href="/admin/equipos" class="btn btn-default btn-sm">Equipos</a>
+            {% if filter_equipo %}
+            <a href="/admin/equipos/plan/{{ filter_equipo }}" class="btn btn-default btn-sm">Plan</a>
+            {% endif %}
             <a href="/admin/equipos/calendario{% if filter_equipo %}?equipo={{ filter_equipo }}{% endif %}" class="btn btn-default btn-sm">Calendario</a>
             <a href="/admin/equipos/revisiones/nuevo{% if filter_equipo %}?equipo={{ filter_equipo }}{% endif %}" class="btn btn-primary btn-sm">
                 <span class="glyphicon glyphicon-plus"></span> Nueva Revisión


### PR DESCRIPTION
## Summary
- Equipo form: edit **mantenimiento cada** + unidad (días/meses)
- **Plan** per equipo (`/admin/equipos/plan/{id}`): interval summary, next due (legacy rules), historial
- **Programar preventivo** POST inserts `mantenimientos` tipo=preventivo with computed date
- Links from list (Plan), form, revisiones (when filtered)
- Patch **0048** demo intervals + base preventivo for due calc
- verify + living docs

## Out of scope
- Batch reminders, ICS, deep correctivo workflows

## Test plan
- [ ] Apply 0048 / verify script
- [ ] Browser: Equipos → Plan → next due visible → Programar preventivo → row in historial
- [ ] Edit interval on form; re-check plan calculation
- [ ] Calendario still shows new preventivo dates