### PR TITLE
feat(9.39): Documentación binario adjunto shell

### DIFF
--- a/.agents/MIGRATION-TODOS.md
+++ b/.agents/MIGRATION-TODOS.md
@@ -5,7 +5,7 @@ MIGRATION-PLAN.md = architecture, constraints, high-level stages + history.
 STAGE-CHECKLISTS.md = detailed per-leg playbooks, exact commands, evidence, retrospective lessons.  
 **This file** = scannable "what is left, how big is it, what should the next PR be?" + handoff package for other agents.
 
-**Last updated**: Stage 9.38 on `feat/stage-9.38-equipos-plan-preventivo` (Equipos plan / auto-preventivo). Previous: 9.37 Auditorías informes.
+**Last updated**: Stage 9.39 on `feat/stage-9.39-documentacion-binario` (Documentación binario shell). Previous: 9.38 Equipos plan.
 
 ---
 
@@ -107,10 +107,11 @@ Pick 1-2 related items that together form a reviewable PR. Update this list when
 - [x] **Equipos calendario first slice**: Delivered in Stage 9.36 (annual calendar over `mantenimientos`, year/equipo filters, tipo markers, links to revisiones, demo patch 0046). See 9.36 plan and STAGE-CHECKLISTS.
 - [x] **Auditorías informes first slice**: Delivered in Stage 9.37 (conclusiones/recomendaciones columns, informe edit + printable HTML ficha, links from ejecución, patch 0047). See 9.37 plan and STAGE-CHECKLISTS.
 - [x] **Equipos plan / auto-preventivo first slice**: Delivered in Stage 9.38 (interval fields on form, plan view, programar preventivo from mantenimiento_cada/dias, patch 0048). See 9.38 plan and STAGE-CHECKLISTS.
+- [x] **Documentación binario first slice**: Delivered in Stage 9.39 (`tipos_fichero` + `contenido_binario`, upload/download/delete, list flag, patch 0049). See 9.39 plan and STAGE-CHECKLISTS.
 - [ ] **Next** (sized picks):  
-  - Documentación rich content / binario · In: metadata + optional file shell · Out: full GenPDF · ~15 files · patch? maybe  
   - Auditorías GenPDF / formal export · In: PDF from ficha · Out: full GenPDF suite · ~10 files · patch? no  
-  - Proveedores homologación · In: evaluation shell · Out: full supplier workflow · ~12 files · patch? maybe
+  - Proveedores homologación · In: evaluation shell · Out: full supplier workflow · ~12 files · patch? maybe  
+  - Documentación WYSIWYG / GenPDF ficha · In: richer editor · Out: full plantillas · ~12 files · patch? maybe
 
 Aim for a mix: one "close the small gaps" + one "new vertical" per couple of legs. Keep delivering working, reviewable increments.
 
@@ -147,8 +148,8 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 - [ ] Batch reminders / ICS / deeper correctivo + ties to Auditorias / Mejora.
 
 ### Documentación (Core ISO — high value, likely larger)
-- [x] Documentación initial shell delivered in Stage 9.5. Tree in 9.12. Editor/perfiles in 9.23, workflows fields in 9.24, content editor (texto) in 9.26. Estado labels + list filter in 9.31. Quick Revisar/Aprobar transitions in 9.34. Full rich editor, binario, more, PDF deferred. See 9.5 + 9.12 + 9.23 + 9.24 + 9.26 + 9.31 + 9.34 plans.
-- [ ] Full tree + editor modernization, formats/plantillas; rich content / binario.
+- [x] Documentación initial shell delivered in Stage 9.5. Tree in 9.12. Editor/perfiles in 9.23, workflows fields in 9.24, content editor (texto) in 9.26. Estado labels + list filter in 9.31. Quick Revisar/Aprobar transitions in 9.34. Binario adjunto (upload/download) in Stage 9.39. See 9.5 + 9.12 + 9.23 + 9.24 + 9.26 + 9.31 + 9.34 + 9.39 plans.
+- [ ] Full tree + editor modernization, formats/plantillas; WYSIWYG rich content.
 - [ ] PDF ficha / export modernization (GenPDF.inc, related) — cross-cutting but surfaces here.
 
 ### Auditorías (Audits)

--- a/.agents/STAGE-CHECKLISTS.md
+++ b/.agents/STAGE-CHECKLISTS.md
@@ -3679,6 +3679,22 @@ docker compose exec db psql -U qnova -d qnova -c "SELECT id, mantenimiento_cada,
 
 **Branch status:** Stage 9.38 on `feat/stage-9.38-equipos-plan-preventivo`.
 
+## Stage 9.39 — Documentación content / binario first slice
+
+**Goal:** `tipos_fichero` + `contenido_binario` (BYTEA); form multipart upload; download + delete; list adjunto flag. Demo patch 0049.
+
+**Validation:**
+```bash
+docker compose exec app php -l Pages/Documentacion/Formulario.php Pages/Documentacion/Binario.php Pages/Documentacion/Listado.php index.php
+docker compose exec -T db psql -U qnova -d qnova < docker/db-init/data-patches/0049-documentacion-binario.sql
+docker compose exec app ./scripts/verify-8.6.sh
+docker compose exec db psql -U qnova -d qnova -c "SELECT COUNT(*) FROM tipos_fichero; SELECT id, nombre_archivo, size FROM contenido_binario;"
+```
+
+**Browser:** `/admin/documentacion` → binario badge on doc 1 → Descargar; edit → replace/remove file.
+
+**Branch status:** Stage 9.39 on `feat/stage-9.39-documentacion-binario`.
+
 
 
 

--- a/Pages/Documentacion/Binario.php
+++ b/Pages/Documentacion/Binario.php
@@ -1,0 +1,183 @@
+<?php
+namespace Tuqan\Pages\Documentacion;
+
+use Tuqan\Classes\Config;
+use Tuqan\Pages\Catalog\CatalogFormulario;
+
+/**
+ * Download / remove document binary attachment (Stage 9.39).
+ */
+class Binario extends CatalogFormulario
+{
+    protected string $table        = 'contenido_binario';
+    protected string $title        = 'Adjunto binario';
+    protected string $templateDir  = 'documentacion';
+    protected string $flashPrefix  = 'documento';
+    protected string $listRoute    = '/admin/documentacion';
+
+    public const MAX_BYTES = 5242880; // 5 MiB
+
+    /**
+     * Stream binary attachment for a document id.
+     */
+    public function Descargar($id = null)
+    {
+        Config::initialize();
+        if ($id === null && isset($_GET['id'])) {
+            $id = (int)$_GET['id'];
+        }
+        $id = (int)$id;
+        if ($id <= 0) {
+            http_response_code(404);
+            echo 'Adjunto no encontrado.';
+            return '';
+        }
+
+        $db = $this->getDb();
+        $db->consultaPreparada(
+            "SELECT cb.contenido, cb.size, cb.nombre_archivo, tf.mime, tf.extension
+             FROM contenido_binario cb
+             LEFT JOIN tipos_fichero tf ON tf.id = cb.tipo_fichero
+             WHERE cb.id = ?",
+            [$id]
+        );
+        // Avoid stripslashes on binary payload
+        $row = $db->coger_Fila(false);
+        $db->desconexion();
+
+        if (!$row || $row[0] === null || $row[0] === '') {
+            http_response_code(404);
+            echo 'Adjunto no encontrado.';
+            return '';
+        }
+
+        $contenido = $row[0];
+        if (is_resource($contenido)) {
+            $contenido = stream_get_contents($contenido);
+        }
+        $size = $row[1] !== null ? (int)$row[1] : strlen($contenido);
+        $nombre = $row[2] ?: ('documento-' . $id . ($row[4] ? ('.' . trim($row[4])) : ''));
+        $mime = $row[3] ?: 'application/octet-stream';
+
+        // Clear any accidental output buffers before binary headers
+        while (ob_get_level() > 0) {
+            ob_end_clean();
+        }
+
+        header('Content-Type: ' . $mime);
+        header('Content-Length: ' . $size);
+        header('Content-Disposition: attachment; filename="' . str_replace(['"', "\r", "\n"], '', $nombre) . '"');
+        header('X-Content-Type-Options: nosniff');
+        echo $contenido;
+        exit;
+    }
+
+    /**
+     * POST: remove binary attachment for document id.
+     */
+    public function Eliminar($id = null)
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            header('Location: ' . $this->listRoute);
+            exit;
+        }
+        Config::initialize();
+        if ($id === null) {
+            $id = (int)($_POST['id'] ?? 0);
+        }
+        $id = (int)$id;
+        if ($id <= 0) {
+            header('Location: ' . $this->listRoute);
+            exit;
+        }
+
+        try {
+            $db = $this->getDb();
+            $db->consultaPreparada('DELETE FROM contenido_binario WHERE id = ?', [$id]);
+            $db->desconexion();
+            $_SESSION[$this->flashPrefix . '_flash_success'] = 'Adjunto eliminado.';
+        } catch (\Throwable $e) {
+            $_SESSION[$this->flashPrefix . '_form_error'] = 'No se pudo eliminar el adjunto.';
+        }
+        header('Location: /admin/documentacion/editar/' . $id);
+        exit;
+    }
+
+    /**
+     * Resolve tipos_fichero id from uploaded filename extension.
+     */
+    public static function resolveTipoFicheroId($db, string $filename): ?int
+    {
+        $ext = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+        if ($ext === '') {
+            return null;
+        }
+        // jpg/jpeg alias
+        if ($ext === 'jpeg') {
+            $ext = 'jpg';
+        }
+        $db->consultaPreparada(
+            "SELECT id FROM tipos_fichero WHERE lower(trim(extension)) = ? LIMIT 1",
+            [$ext]
+        );
+        $row = $db->coger_Fila();
+        if ($row) {
+            return (int)$row[0];
+        }
+        // Insert unknown extension as generic octet-stream type
+        $db->consultaPreparada(
+            "INSERT INTO tipos_fichero (nombre, extension, mime) VALUES (?, ?, 'application/octet-stream')",
+            [strtoupper($ext), $ext]
+        );
+        $db->consultaPreparada(
+            "SELECT id FROM tipos_fichero WHERE lower(trim(extension)) = ? ORDER BY id DESC LIMIT 1",
+            [$ext]
+        );
+        $row = $db->coger_Fila();
+        return $row ? (int)$row[0] : null;
+    }
+
+    /**
+     * Persist uploaded file into contenido_binario for document $docId.
+     * @return string|null error message or null on success / no file
+     */
+    public static function persistUpload($db, int $docId, array $file): ?string
+    {
+        if (($file['error'] ?? UPLOAD_ERR_NO_FILE) === UPLOAD_ERR_NO_FILE) {
+            return null;
+        }
+        if (($file['error'] ?? UPLOAD_ERR_OK) !== UPLOAD_ERR_OK) {
+            return 'Error al subir el archivo (código ' . (int)$file['error'] . ').';
+        }
+        $size = (int)($file['size'] ?? 0);
+        if ($size <= 0) {
+            return 'El archivo está vacío.';
+        }
+        if ($size > self::MAX_BYTES) {
+            return 'El archivo supera el máximo de 5 MB.';
+        }
+        $tmp = $file['tmp_name'] ?? '';
+        if ($tmp === '' || !is_uploaded_file($tmp)) {
+            return 'Archivo temporal no válido.';
+        }
+        $bytes = file_get_contents($tmp);
+        if ($bytes === false) {
+            return 'No se pudo leer el archivo subido.';
+        }
+        $nombre = basename((string)($file['name'] ?? 'adjunto'));
+        $nombre = preg_replace('/[^\w.\- ()áéíóúÁÉÍÓÚñÑ]+/u', '_', $nombre) ?: 'adjunto';
+        $tipoId = self::resolveTipoFicheroId($db, $nombre);
+
+        $db->consultaPreparada(
+            "INSERT INTO contenido_binario (id, tipo_fichero, size, contenido, nombre_archivo)
+             VALUES (?, ?, ?, ?, ?)
+             ON CONFLICT (id) DO UPDATE SET
+               tipo_fichero = EXCLUDED.tipo_fichero,
+               size = EXCLUDED.size,
+               contenido = EXCLUDED.contenido,
+               nombre_archivo = EXCLUDED.nombre_archivo",
+            [$docId, $tipoId, strlen($bytes), $bytes, $nombre]
+        );
+        return null;
+    }
+}

--- a/Pages/Documentacion/Formulario.php
+++ b/Pages/Documentacion/Formulario.php
@@ -27,10 +27,34 @@ class Formulario extends CatalogFormulario
         $db->consultaPreparada($this->getSelectForForm(), [$id]);
         $row = $db->coger_Fila();
         $contenido = '';
+        $binario = null;
         if ($row) {
             $db->consultaPreparada("SELECT contenido FROM contenido_texto WHERE id = ?", [$id]);
             $crow = $db->coger_Fila();
             if ($crow) $contenido = $crow[0] ?? '';
+            // 9.39 binary attachment metadata (no payload in form)
+            try {
+                $db->consultaPreparada(
+                    "SELECT cb.size, cb.nombre_archivo, tf.nombre, tf.extension, tf.mime
+                     FROM contenido_binario cb
+                     LEFT JOIN tipos_fichero tf ON tf.id = cb.tipo_fichero
+                     WHERE cb.id = ?",
+                    [$id]
+                );
+                $brow = $db->coger_Fila();
+                if ($brow) {
+                    $binario = [
+                        'size'           => $brow[0] !== null ? (int)$brow[0] : null,
+                        'nombre_archivo' => $brow[1] ?? null,
+                        'tipo_nombre'    => $brow[2] ?? null,
+                        'extension'      => $brow[3] ? trim($brow[3]) : null,
+                        'mime'           => $brow[4] ?? null,
+                        'size_label'     => self::formatBytes($brow[0] !== null ? (int)$brow[0] : 0),
+                    ];
+                }
+            } catch (\Throwable $e) {
+                $binario = null;
+            }
         }
         $db->desconexion();
         if (!$row) return null;
@@ -57,7 +81,20 @@ class Formulario extends CatalogFormulario
             'fecha_revision'    => $row[19] ?? null,
             'fecha_aprobacion'  => $row[20] ?? null,
             'contenido'         => $contenido,
+            'binario'           => $binario,
+            'has_binario'       => $binario !== null,
         ];
+    }
+
+    public static function formatBytes(int $bytes): string
+    {
+        if ($bytes < 1024) {
+            return $bytes . ' B';
+        }
+        if ($bytes < 1048576) {
+            return round($bytes / 1024, 1) . ' KB';
+        }
+        return round($bytes / 1048576, 2) . ' MB';
     }
 
     protected function buildFormVariables(?array $item): array
@@ -69,6 +106,7 @@ class Formulario extends CatalogFormulario
         $vars['area_options'] = $this->getRelatedOptions('areas', 'nombre');
         $vars['usuario_options'] = $this->getRelatedOptions('usuarios', 'nombre');
         $vars['estado_options'] = EstadoHelper::options();
+        $vars['max_upload_mb'] = (int)(Binario::MAX_BYTES / 1048576);
 
         $key = strtolower($this->flashPrefix);
         if (!empty($vars[$key])) {
@@ -79,6 +117,7 @@ class Formulario extends CatalogFormulario
             $d['aprobado_por_label'] = $this->getRelatedLabel('usuarios', $d['aprobado_por'] ?? null);
             $d['estado_label'] = EstadoHelper::label($d['estado'] ?? null);
             $d['estado_badge'] = EstadoHelper::badgeClass($d['estado'] ?? null);
+            $d['contenido_len'] = strlen((string)($d['contenido'] ?? ''));
             $vars[$key] = $d;
         }
         return $vars;
@@ -204,7 +243,65 @@ class Formulario extends CatalogFormulario
             "INSERT INTO contenido_texto (id, contenido) VALUES (?, ?) ON CONFLICT (id) DO UPDATE SET contenido = ?",
             [$doc_id, $data['contenido'], $data['contenido']]
         );
+
+        // 9.39 binary attachment upload (optional)
+        if (!empty($_FILES['archivo']) && is_array($_FILES['archivo'])) {
+            $uploadErr = Binario::persistUpload($db, (int)$doc_id, $_FILES['archivo']);
+            if ($uploadErr !== null) {
+                $db->desconexion();
+                // Surface via session; document meta already saved
+                $_SESSION[$this->flashPrefix . '_form_error'] = $uploadErr;
+                return;
+            }
+        }
         $db->desconexion();
+    }
+
+    /**
+     * After save, stay on edit form when upload error; otherwise list.
+     */
+    public function Procesar($id = null)
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            header("Location: {$this->listRoute}");
+            exit;
+        }
+
+        Config::initialize();
+
+        if ($id === null) {
+            $id = isset($_POST['id']) ? (int)$_POST['id'] : (isset($_GET['id']) ? (int)$_GET['id'] : null);
+        }
+        $id = (int)$id;
+
+        $data = $this->getPostData();
+        $errors = $this->validate($data);
+        if (!empty($errors)) {
+            $_SESSION[$this->flashPrefix . '_form_error'] = implode(' ', $errors);
+            $target = $id > 0 ? "{$this->listRoute}/editar/$id" : "{$this->listRoute}/nuevo";
+            header("Location: $target");
+            exit;
+        }
+
+        $this->persist($data, $id);
+
+        // If persist flagged upload error, return to edit (need doc id)
+        if (!empty($_SESSION[$this->flashPrefix . '_form_error'])) {
+            // resolve id after insert
+            if ($id <= 0) {
+                // best effort: list
+                header("Location: {$this->listRoute}");
+                exit;
+            }
+            header("Location: {$this->listRoute}/editar/$id");
+            exit;
+        }
+
+        $msg = $this->getSuccessMessage($id > 0);
+        $_SESSION[$this->flashPrefix . '_flash_success'] = $msg;
+        // After create with file, go to list; edits go to list too (consistent)
+        header("Location: {$this->listRoute}");
+        exit;
     }
 
     // --- Quick workflow actions (Stage 9.34) — one-click from list ---

--- a/Pages/Documentacion/Listado.php
+++ b/Pages/Documentacion/Listado.php
@@ -64,9 +64,27 @@ class Listado extends CatalogListado
             $item['aprobado_por_label'] = $this->getRelatedLabel('usuarios', $item['aprobado_por'] ?? null);
             $item['estado_label'] = EstadoHelper::label($item['estado'] ?? null);
             $item['estado_badge'] = EstadoHelper::badgeClass($item['estado'] ?? null);
+            $item['has_binario'] = $this->hasBinario((int)$item['id']);
         }
         unset($item);
         return $items;
+    }
+
+    // 9.39: presence of contenido_binario row
+    protected function hasBinario(int $docId): bool
+    {
+        if ($docId <= 0) {
+            return false;
+        }
+        try {
+            $db = $this->getDb();
+            $db->consultaPreparada('SELECT 1 FROM contenido_binario WHERE id = ?', [$docId]);
+            $row = $db->coger_Fila();
+            $db->desconexion();
+            return (bool)$row;
+        } catch (\Throwable $e) {
+            return false;
+        }
     }
 
     protected function buildListVariables(array $items): array

--- a/docker/db-init/data-patches/0049-documentacion-binario.sql
+++ b/docker/db-init/data-patches/0049-documentacion-binario.sql
@@ -1,0 +1,57 @@
+-- 0049-documentacion-binario.sql
+-- Stage 9.39: tipos_fichero + contenido_binario for document file attachments.
+-- Modern shell stores payload in BYTEA (legacy also has archivo_oid LO; deferred).
+
+CREATE TABLE IF NOT EXISTS tipos_fichero (
+  id        SERIAL PRIMARY KEY,
+  nombre    CHARACTER VARYING(32),
+  extension CHARACTER VARYING(8),
+  mime      CHARACTER VARYING(128)
+);
+
+-- Live DBs may have created tipos_fichero with mime VARCHAR(64) on a partial run
+ALTER TABLE tipos_fichero ALTER COLUMN mime TYPE CHARACTER VARYING(128);
+
+CREATE TABLE IF NOT EXISTS contenido_binario (
+  id           INTEGER PRIMARY KEY,
+  tipo_fichero INTEGER REFERENCES tipos_fichero (id),
+  size         BIGINT,
+  contenido    BYTEA,
+  archivo_oid  OID,
+  nombre_archivo CHARACTER VARYING(255)
+);
+
+-- Seed common types (idempotent by extension)
+INSERT INTO tipos_fichero (nombre, extension, mime)
+SELECT 'PDF', 'pdf', 'application/pdf'
+WHERE NOT EXISTS (SELECT 1 FROM tipos_fichero WHERE lower(trim(extension)) = 'pdf');
+
+INSERT INTO tipos_fichero (nombre, extension, mime)
+SELECT 'Texto', 'txt', 'text/plain'
+WHERE NOT EXISTS (SELECT 1 FROM tipos_fichero WHERE lower(trim(extension)) = 'txt');
+
+INSERT INTO tipos_fichero (nombre, extension, mime)
+SELECT 'PNG', 'png', 'image/png'
+WHERE NOT EXISTS (SELECT 1 FROM tipos_fichero WHERE lower(trim(extension)) = 'png');
+
+INSERT INTO tipos_fichero (nombre, extension, mime)
+SELECT 'JPEG', 'jpg', 'image/jpeg'
+WHERE NOT EXISTS (SELECT 1 FROM tipos_fichero WHERE lower(trim(extension)) = 'jpg');
+
+INSERT INTO tipos_fichero (nombre, extension, mime)
+SELECT 'Word', 'docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+WHERE NOT EXISTS (SELECT 1 FROM tipos_fichero WHERE lower(trim(extension)) = 'docx');
+
+-- Demo binary for documento 1 (plain text payload as BYTEA, tipo txt)
+INSERT INTO contenido_binario (id, tipo_fichero, size, contenido, nombre_archivo)
+SELECT 1,
+       (SELECT id FROM tipos_fichero WHERE lower(trim(extension)) = 'txt' LIMIT 1),
+       octet_length(convert_to('Documento adjunto demo Stage 9.39 — Manual de Calidad (MAN-001).' || E'\n', 'UTF8')),
+       convert_to('Documento adjunto demo Stage 9.39 — Manual de Calidad (MAN-001).' || E'\n', 'UTF8'),
+       'man-001-demo.txt'
+WHERE EXISTS (SELECT 1 FROM documentos WHERE id = 1)
+  AND NOT EXISTS (SELECT 1 FROM contenido_binario WHERE id = 1);
+
+INSERT INTO data_patches (filename, applied_at)
+VALUES ('0049-documentacion-binario.sql', NOW())
+ON CONFLICT (filename) DO NOTHING;

--- a/index.php
+++ b/index.php
@@ -421,6 +421,10 @@ $router->addRoute('POST', '/admin/documentacion/enviar-revision/{id}', ['Tuqan\P
 $router->addRoute('POST', '/admin/documentacion/revisar/{id}', ['Tuqan\Pages\Documentacion\Formulario', 'Revisar'], ['before' => 'auth_company']);
 $router->addRoute('POST', '/admin/documentacion/aprobar/{id}', ['Tuqan\Pages\Documentacion\Formulario', 'Aprobar'], ['before' => 'auth_company']);
 
+// Binary attachment download / delete (Stage 9.39)
+$router->addRoute('GET', '/admin/documentacion/binario/{id}', ['Tuqan\Pages\Documentacion\Binario', 'Descargar'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/documentacion/binario/{id}/eliminar', ['Tuqan\Pages\Documentacion\Binario', 'Eliminar'], ['before' => 'auth_company']);
+
 // Key legacy for Documentación (vigor / borradores + general)
 $router->addRoute('GET', '/administracion/documentacion/docvigor/listado/ver', ['Tuqan\Pages\Documentacion\Listado', 'ShowPage'], ['before' => 'auth_company']);
 $router->addRoute('GET', '/administracion/documentacion/docborrador/listado/ver', ['Tuqan\Pages\Documentacion\Listado', 'ShowPage'], ['before' => 'auth_company']);

--- a/reference/stage-9.39-documentacion-binario-plan.md
+++ b/reference/stage-9.39-documentacion-binario-plan.md
@@ -1,0 +1,23 @@
+# Stage 9.39 — Documentación content / binario first slice
+
+**Status**: Planning (plan first)
+**Branch**: `feat/stage-9.39-documentacion-binario`
+**Driver**: Sized next after 9.38. Text content exists (9.26); legacy `contenido_binario` + `tipos_fichero` + muestrabinario not modernized. Tables missing from minimal DB.
+
+## Goals
+1. Patch **0049**: CREATE `tipos_fichero` + `contenido_binario` (+ PK); seed mime types; demo binario for doc 1 (BYTEA, not large-object OID).
+2. Document form: multipart upload; show binario metadata (tipo, size); remove attachment option.
+3. Download route `/admin/documentacion/binario/{id}` (Content-Type from tipos_fichero).
+4. Listado: flag if documento has binario; download shortcut.
+5. Slight content UX polish (taller textarea + char hint) — not full WYSIWYG.
+6. verify + playbook + TODOS.
+
+## Out
+- GenPDF, large-object OID pipeline, full FCKeditor/WYSIWYG, multi-adjunto (contenido_adjunto).
+
+## Sizing
+- One outcome: attach/download binary file on a document + see it in list.
+- ~12–15 files, 1 patch.
+
+---
+*Plan committed first. Docker-only.*

--- a/reference/stage-9.39-documentacion-binario-plan.md
+++ b/reference/stage-9.39-documentacion-binario-plan.md
@@ -1,6 +1,6 @@
 # Stage 9.39 — Documentación content / binario first slice
 
-**Status**: Planning (plan first)
+**Status**: Implemented (verify + PR)
 **Branch**: `feat/stage-9.39-documentacion-binario`
 **Driver**: Sized next after 9.38. Text content exists (9.26); legacy `contenido_binario` + `tipos_fichero` + muestrabinario not modernized. Tables missing from minimal DB.
 

--- a/scripts/verify-8.6.sh
+++ b/scripts/verify-8.6.sh
@@ -164,6 +164,15 @@ SELECT id, mantenimiento_cada, dias FROM equipos WHERE id IN (1, 2) ORDER BY id;
 SELECT COUNT(*) AS preventivos_equipo1 FROM mantenimientos WHERE equipo = 1 AND tipo = 'preventivo';
 SELECT COUNT(*) AS plan_demo_rows FROM mantenimientos WHERE comentarios LIKE 'Plan demo:%';
 
+-- 9.39 Documentación binario evidence
+SELECT '0049-documentacion-binario.sql' AS patch, COUNT(*) FROM data_patches WHERE filename = '0049-documentacion-binario.sql';
+SELECT COUNT(*) AS tipos_fichero_rows FROM tipos_fichero;
+SELECT COUNT(*) AS contenido_binario_rows FROM contenido_binario;
+SELECT cb.id, cb.nombre_archivo, cb.size, tf.extension
+  FROM contenido_binario cb
+  LEFT JOIN tipos_fichero tf ON tf.id = cb.tipo_fichero
+ ORDER BY cb.id LIMIT 5;
+
 -- 9.5 Formación (Planes) + Documentación evidence
 SELECT COUNT(*) AS plan_formacion_rows FROM plan_formacion;
 SELECT COUNT(*) AS documentos_rows FROM documentos;

--- a/templates/documentacion/formulario.twig
+++ b/templates/documentacion/formulario.twig
@@ -12,8 +12,9 @@
     </div>
 </div>
 
-<div style="padding: 20px; max-width: 700px;">
-    <form method="POST" action="{{ isEdit ? '/admin/documentacion/editar/' ~ documento.id : '/admin/documentacion/nuevo' }}">
+<div style="padding: 20px; max-width: 780px;">
+    <form method="POST" action="{{ isEdit ? '/admin/documentacion/editar/' ~ documento.id : '/admin/documentacion/nuevo' }}"
+          enctype="multipart/form-data">
         {% if isEdit %}
             <input type="hidden" name="id" value="{{ documento.id }}">
         {% endif %}
@@ -32,8 +33,38 @@
 
         <div class="form-group">
             <label for="contenido">Contenido (texto)</label>
-            <textarea class="form-control" id="contenido" name="contenido" rows="8">{{ documento.contenido ?? '' }}</textarea>
+            <textarea class="form-control" id="contenido" name="contenido" rows="12"
+                      style="font-family: Menlo, Monaco, Consolas, monospace; font-size: 13px;">{{ documento.contenido ?? '' }}</textarea>
+            <p class="help-block" style="margin-bottom:0;">
+                {{ documento.contenido_len ?? 0 }} caracteres · texto en <code>contenido_texto</code>
+            </p>
         </div>
+
+        <fieldset style="margin: 18px 0; padding-top: 12px; border-top: 1px solid #eee;">
+            <legend style="font-size: 14px; border:0; margin-bottom: 10px;">Adjunto binario</legend>
+            {% if isEdit and documento.has_binario and documento.binario %}
+                <div class="alert alert-success" style="padding:10px 12px;">
+                    <strong>{{ documento.binario.nombre_archivo ?? 'Adjunto' }}</strong>
+                    · {{ documento.binario.tipo_nombre ?? 'archivo' }}
+                    {% if documento.binario.extension %}(.{{ documento.binario.extension }}){% endif %}
+                    · {{ documento.binario.size_label }}
+                    · <a href="/admin/documentacion/binario/{{ documento.id }}">Descargar</a>
+                </div>
+                <div style="margin-bottom: 10px;">
+                    <button type="submit" form="form-eliminar-binario" class="btn btn-danger btn-xs"
+                            onclick="return confirm('¿Eliminar el adjunto?');">Eliminar adjunto</button>
+                </div>
+            {% elseif isEdit %}
+                <p class="text-muted">Sin adjunto binario todavía.</p>
+            {% else %}
+                <p class="text-muted">Puede adjuntar un archivo al crear el documento (máx. {{ max_upload_mb }} MB).</p>
+            {% endif %}
+            <div class="form-group" style="margin-bottom:0;">
+                <label for="archivo">{% if isEdit and documento.has_binario %}Reemplazar archivo{% else %}Subir archivo{% endif %}</label>
+                <input type="file" class="form-control" id="archivo" name="archivo">
+                <p class="help-block" style="margin-bottom:0;">PDF, TXT, PNG, JPG, DOCX u otros · máx. {{ max_upload_mb }} MB · tabla <code>contenido_binario</code></p>
+            </div>
+        </fieldset>
 
         {% if isEdit and documento.estado is not null %}
         <div class="form-group">
@@ -199,8 +230,12 @@
         </div>
 
         <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
-            Documentación (9.5–9.31 + 9.34). Workflow: enviar a revisión / revisar / aprobar. Rich editor deferred.
+            Documentación (9.5–9.39). Texto + adjunto binario. WYSIWYG / GenPDF / large objects deferred.
         </div>
     </form>
+
+    {% if isEdit and documento.id and documento.has_binario %}
+    <form id="form-eliminar-binario" method="POST" action="/admin/documentacion/binario/{{ documento.id }}/eliminar" style="display:none;"></form>
+    {% endif %}
 </div>
 {% endblock %}

--- a/templates/documentacion/listado.twig
+++ b/templates/documentacion/listado.twig
@@ -58,10 +58,11 @@
                         <th>Nombre</th>
                         <th>Código</th>
                         <th>Estado</th>
+                        <th>Adjunto</th>
                         <th>Revisado por</th>
                         <th>Aprobado por</th>
                         <th>Activo</th>
-                        <th style="width:260px;text-align:right;">Acciones</th>
+                        <th style="width:280px;text-align:right;">Acciones</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -73,11 +74,21 @@
                         <td>
                             <span class="label {{ d.estado_badge|default('label-default') }}">{{ d.estado_label ?? (d.estado ?? '—') }}</span>
                         </td>
+                        <td>
+                            {% if d.has_binario %}
+                                <a href="/admin/documentacion/binario/{{ d.id }}" class="label label-info" title="Descargar adjunto">binario</a>
+                            {% else %}
+                                <span class="text-muted">—</span>
+                            {% endif %}
+                        </td>
                         <td>{{ d.revisado_por_label ?? (d.revisado_por ?? '-') }}</td>
                         <td>{{ d.aprobado_por_label ?? (d.aprobado_por ?? '-') }}</td>
                         <td>{% if d.activo %}<span class="label label-success">Activo</span>{% else %}<span class="label label-default">Inactivo</span>{% endif %}</td>
                         <td style="text-align:right; white-space: nowrap;">
                             <a href="/admin/documentacion/editar/{{ d.id }}" class="btn btn-xs btn-default">Editar</a>
+                            {% if d.has_binario %}
+                            <a href="/admin/documentacion/binario/{{ d.id }}" class="btn btn-xs btn-info">Descargar</a>
+                            {% endif %}
                             {% if d.estado is null or d.estado == 2 %}
                                 <form method="POST" action="/admin/documentacion/enviar-revision/{{ d.id }}" style="display:inline;margin-left:2px;">
                                     <button type="submit" class="btn btn-xs btn-warning" title="Estado → Pend. revisión">A revisión</button>
@@ -101,7 +112,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Documentación (9.5–9.31 + 9.34 workflow: A revisión / Revisar / Aprobar). Rich editor deferred.
+        Documentación (9.5–9.39: workflow + texto + adjunto binario). WYSIWYG / GenPDF deferred.
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Patch **0049**: `tipos_fichero` + `contenido_binario` (BYTEA + `nombre_archivo`); seed types + demo txt on doc 1
- Document form: multipart upload/replace; metadata + download/delete
- Routes: `GET /admin/documentacion/binario/{id}`, `POST .../eliminar`
- Listado: adjunto column + Descargar
- Content textarea polish (taller mono + char count)
- verify + living docs

## Out of scope
- WYSIWYG, GenPDF, large-object OID pipeline, multi-adjunto

## Test plan
- [ ] Apply 0049 / verify script
- [ ] List: doc 1 shows binario badge → Descargar
- [ ] Edit: replace file, download, eliminate adjunto
- [ ] Create with file upload