### PR TITLE
feat(9.40): Proveedores homologación shell

### DIFF
--- a/.agents/MIGRATION-TODOS.md
+++ b/.agents/MIGRATION-TODOS.md
@@ -5,7 +5,7 @@ MIGRATION-PLAN.md = architecture, constraints, high-level stages + history.
 STAGE-CHECKLISTS.md = detailed per-leg playbooks, exact commands, evidence, retrospective lessons.  
 **This file** = scannable "what is left, how big is it, what should the next PR be?" + handoff package for other agents.
 
-**Last updated**: Stage 9.39 on `feat/stage-9.39-documentacion-binario` (Documentación binario shell). Previous: 9.38 Equipos plan.
+**Last updated**: Stage 9.40 on `feat/stage-9.40-proveedores-homologacion` (Proveedores homologación shell). Previous: 9.39 Documentación binario.
 
 ---
 
@@ -108,9 +108,10 @@ Pick 1-2 related items that together form a reviewable PR. Update this list when
 - [x] **Auditorías informes first slice**: Delivered in Stage 9.37 (conclusiones/recomendaciones columns, informe edit + printable HTML ficha, links from ejecución, patch 0047). See 9.37 plan and STAGE-CHECKLISTS.
 - [x] **Equipos plan / auto-preventivo first slice**: Delivered in Stage 9.38 (interval fields on form, plan view, programar preventivo from mantenimiento_cada/dias, patch 0048). See 9.38 plan and STAGE-CHECKLISTS.
 - [x] **Documentación binario first slice**: Delivered in Stage 9.39 (`tipos_fichero` + `contenido_binario`, upload/download/delete, list flag, patch 0049). See 9.39 plan and STAGE-CHECKLISTS.
+- [x] **Proveedores homologación first slice**: Delivered in Stage 9.40 (proveedor dates + Homologar/Deshomologar, productos, criterios catalog, patch 0050). See 9.40 plan and STAGE-CHECKLISTS.
 - [ ] **Next** (sized picks):  
   - Auditorías GenPDF / formal export · In: PDF from ficha · Out: full GenPDF suite · ~10 files · patch? no  
-  - Proveedores homologación · In: evaluation shell · Out: full supplier workflow · ~12 files · patch? maybe  
+  - Proveedores contactos / incidencias · In: sub-entity shell · Out: full supplier suite · ~12 files · patch? maybe  
   - Documentación WYSIWYG / GenPDF ficha · In: richer editor · Out: full plantillas · ~12 files · patch? maybe
 
 Aim for a mix: one "close the small gaps" + one "new vertical" per couple of legs. Keep delivering working, reviewable increments.
@@ -140,8 +141,8 @@ Aim for a mix: one "close the small gaps" + one "new vertical" per couple of leg
 - [ ] Link to Empleados / RRHH concepts if present in legacy (ficha personal); remaining Formación subs beyond the three modern tables.
 
 ### Proveedores (Suppliers)
-- [x] Proveedores (legacy 67) — basic listado + form (nombre + telefono + activo) in Stage 9.2. Followed catalog base + full routes + data patch + verify + playbook. Sub-entities (contactos, incidencias, productos/homologados) deferred to later legs. (See 9.2 plan and STAGE-CHECKLISTS.)
-- [ ] Homologacion / evaluation flows (common in ISO supplier management).
+- [x] Proveedores (legacy 67) — basic listado + form (nombre + telefono + activo) in Stage 9.2. Homologación (dates, productos, criterios) in Stage 9.40. (See 9.2 + 9.40 plans.)
+- [ ] Contactos / incidencias; multi-criterio scoring + historico_productos.
 
 ### Equipos (Equipment / Assets)
 - [x] Equipos (legacy 70) — basic listado + form (core fields: numero, descripcion, modelo, ubicacion, activo + supporting) in Stage 9.3. Revisiones shell (`mantenimientos` CRUD + links) in Stage 9.33. Calendario anual shell in Stage 9.36. Plan + auto-preventivo from `mantenimiento_cada`/`dias` in Stage 9.38. (See 9.3 + 9.33 + 9.36 + 9.38 plans.)

--- a/.agents/STAGE-CHECKLISTS.md
+++ b/.agents/STAGE-CHECKLISTS.md
@@ -3695,6 +3695,21 @@ docker compose exec db psql -U qnova -d qnova -c "SELECT COUNT(*) FROM tipos_fic
 
 **Branch status:** Stage 9.39 on `feat/stage-9.39-documentacion-binario`.
 
+## Stage 9.40 — Proveedores homologación first slice
+
+**Goal:** Homologation fields + quick Homologar/Deshomologar on proveedores; productos CRUD (filter by proveedor); criterios_homologacion catalog; patch 0050.
+
+**Validation:**
+```bash
+docker compose exec app php -l Pages/Proveedores/Formulario.php Pages/Proveedores/Listado.php Pages/Proveedores/Productos/Listado.php Pages/Proveedores/Criterios/Listado.php index.php
+docker compose exec -T db psql -U qnova -d qnova < docker/db-init/data-patches/0050-proveedores-homologacion.sql
+docker compose exec app ./scripts/verify-8.6.sh
+```
+
+**Browser:** `/admin/proveedores` → Homologar/Deshomologar; Productos filter; Criterios CRUD.
+
+**Branch status:** Stage 9.40 on `feat/stage-9.40-proveedores-homologacion`.
+
 
 
 

--- a/Pages/Proveedores/Criterios/Formulario.php
+++ b/Pages/Proveedores/Criterios/Formulario.php
@@ -1,0 +1,73 @@
+<?php
+namespace Tuqan\Pages\Proveedores\Criterios;
+
+use Tuqan\Pages\Catalog\CatalogFormulario;
+
+class Formulario extends CatalogFormulario
+{
+    protected string $table        = 'criterios_homologacion';
+    protected string $title        = 'Criterio de Homologación';
+    protected string $templateDir  = 'proveedores/criterios';
+    protected string $flashPrefix  = 'criterio';
+    protected string $listRoute    = '/admin/proveedores/criterios';
+
+    protected function getSelectForForm(): string
+    {
+        return "SELECT id, nombre, valor, activo FROM {$this->table} WHERE id = ?";
+    }
+
+    protected function loadItem($id): ?array
+    {
+        if ($id <= 0) {
+            return null;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada($this->getSelectForForm(), [$id]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row) {
+            return null;
+        }
+        return [
+            'id'     => $row[0],
+            'nombre' => $row[1],
+            'valor'  => $row[2] ?? 0,
+            'activo' => $row[3],
+        ];
+    }
+
+    protected function getPostData(): array
+    {
+        return [
+            'nombre' => trim($_POST['nombre'] ?? ''),
+            'valor'  => isset($_POST['valor']) ? (int)$_POST['valor'] : 0,
+            'activo' => !empty($_POST['activo']) ? 1 : 0,
+        ];
+    }
+
+    protected function validate(array $data): array
+    {
+        $errors = [];
+        if (($data['nombre'] ?? '') === '') {
+            $errors[] = 'El nombre del criterio es obligatorio.';
+        }
+        return $errors;
+    }
+
+    protected function persist(array $data, $id)
+    {
+        $db = $this->getDb();
+        if ($id > 0) {
+            $db->consultaPreparada(
+                "UPDATE {$this->table} SET nombre = ?, valor = ?, activo = ? WHERE id = ?",
+                [$data['nombre'], $data['valor'], $data['activo'], $id]
+            );
+        } else {
+            $db->consultaPreparada(
+                "INSERT INTO {$this->table} (nombre, valor, activo) VALUES (?, ?, ?)",
+                [$data['nombre'], $data['valor'], $data['activo']]
+            );
+        }
+        $db->desconexion();
+    }
+}

--- a/Pages/Proveedores/Criterios/Listado.php
+++ b/Pages/Proveedores/Criterios/Listado.php
@@ -1,0 +1,34 @@
+<?php
+namespace Tuqan\Pages\Proveedores\Criterios;
+
+use Tuqan\Pages\Catalog\CatalogListado;
+
+class Listado extends CatalogListado
+{
+    protected string $table       = 'criterios_homologacion';
+    protected string $title       = 'Criterios de Homologación';
+    protected string $templateDir = 'proveedores/criterios';
+    protected string $flashPrefix = 'criterio';
+
+    protected function getSelectSql(): string
+    {
+        return "SELECT id, nombre, valor, activo FROM {$this->table} ORDER BY id";
+    }
+
+    protected function mapRow($row): array
+    {
+        return [
+            'id'     => $row[0],
+            'nombre' => $row[1],
+            'valor'  => $row[2] ?? 0,
+            'activo' => $row[3],
+        ];
+    }
+
+    protected function buildListVariables(array $items): array
+    {
+        $vars = parent::buildListVariables($items);
+        $vars['criterio'] = $items;
+        return $vars;
+    }
+}

--- a/Pages/Proveedores/Formulario.php
+++ b/Pages/Proveedores/Formulario.php
@@ -1,147 +1,208 @@
 <?php
-
 namespace Tuqan\Pages\Proveedores;
 
+use Tuqan\Classes\Config;
 use Tuqan\Pages\Catalog\CatalogFormulario;
 
 class Formulario extends CatalogFormulario
 {
-    protected string $table          = 'proveedores';
-    protected string $title          = 'Proveedores';
+    protected string $table        = 'proveedores';
+    protected string $title        = 'Proveedores';
     protected string $templateDir  = 'proveedores';
     protected string $flashPrefix  = 'proveedor';
     protected string $listRoute    = '/admin/proveedores';
 
-    /**
-     * Override to include telefono field in the query.
-     */
-    protected function getSelectSql(): string
+    protected function getSelectForForm(): string
     {
-        return "SELECT id, nombre, telefono, activo FROM {$this->table} ORDER BY id";
+        return "SELECT id, nombre, telefono, activo, direccion, web, cif,
+                       fecha_homologacion, ultima_revision, fecha_deshomologacion
+                FROM {$this->table} WHERE id = ?";
     }
 
-    public function ShowPage($id = null)
+    protected function loadItem($id): ?array
     {
-        \Tuqan\Classes\Config::initialize();
-
-        $loader = new \Twig\Loader\FilesystemLoader(\Tuqan\Classes\Config::$template_path);
-        $twig   = new \Twig\Environment($loader, [
-            'cache' => \Tuqan\Classes\Config::$cache_path,
-        ]);
-
-        $mainPage     = new \Tuqan\Pages\MainPage();
-        $sidebarMenu  = $mainPage->buildSidebarMenuHtml();
-
-        if ($id === null) {
-            $id = isset($_GET['id']) ? (int)$_GET['id'] : null;
+        if ($id <= 0) {
+            return null;
         }
-        $id = (int)$id;
-        $item = null;
+        $db = $this->getDb();
+        $db->consultaPreparada($this->getSelectForForm(), [$id]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row) {
+            return null;
+        }
+        return [
+            'id'                    => $row[0],
+            'nombre'                => $row[1],
+            'telefono'              => $row[2] ?? null,
+            'activo'                => $row[3],
+            'direccion'             => $row[4] ?? null,
+            'web'                   => $row[5] ?? null,
+            'cif'                   => $row[6] ?? null,
+            'fecha_homologacion'    => $row[7] ?? null,
+            'ultima_revision'       => $row[8] ?? null,
+            'fecha_deshomologacion' => $row[9] ?? null,
+        ];
+    }
 
-        if ($id > 0) {
-            $host    = $_SESSION['db_host'] ?? (getenv('DB_HOST') ?: 'localhost');
-            $port    = $_SESSION['db_port'] ?? (int)(getenv('DB_PORT') ?: 5432);
+    protected function buildFormVariables(?array $item): array
+    {
+        $vars = parent::buildFormVariables($item);
+        $key = strtolower($this->flashPrefix);
+        $vars['productos_relacionados'] = [];
+        $vars['flash_success'] = $_SESSION[$this->flashPrefix . '_flash_success'] ?? null;
+        $vars['flash_error'] = $_SESSION[$this->flashPrefix . '_form_error'] ?? null;
+        unset($_SESSION[$this->flashPrefix . '_flash_success'], $_SESSION[$this->flashPrefix . '_form_error']);
 
-            $db      = new \Tuqan\Classes\Manejador_Base_Datos(
-                $_SESSION['login'] ?? '',
-                $_SESSION['pass'] ?? '',
-                $_SESSION['db'] ?? '',
-                $host,
-                $port
+        if (!empty($vars[$key])) {
+            $p = $vars[$key];
+            $p['homologado'] = HomologacionHelper::isHomologado(
+                $p['fecha_homologacion'] ?? null,
+                $p['fecha_deshomologacion'] ?? null
             );
+            $p['homologacion_label'] = HomologacionHelper::label(
+                $p['fecha_homologacion'] ?? null,
+                $p['fecha_deshomologacion'] ?? null
+            );
+            $p['homologacion_badge'] = HomologacionHelper::badgeClass(
+                $p['fecha_homologacion'] ?? null,
+                $p['fecha_deshomologacion'] ?? null
+            );
+            $vars[$key] = $p;
+            if (!empty($p['id'])) {
+                $vars['productos_relacionados'] = $this->fetchProductos((int)$p['id']);
+            }
+        }
+        return $vars;
+    }
 
+    protected function fetchProductos(int $proveedorId): array
+    {
+        try {
+            $db = $this->getDb();
             $db->consultaPreparada(
-                "SELECT id, nombre, telefono FROM {$this->table} WHERE id = ?",
-                [$id]
+                'SELECT id, nombre, valor, homologado, activo FROM productos WHERE proveedor = ? ORDER BY id',
+                [$proveedorId]
             );
-            $row = $db->coger_Fila();
-            if ($row) {
-                $item = [
-                    'id'        => $row[0],
-                    'nombre'    => $row[1],
-                    'telefono'  => $row[2] ?? null,
+            $items = [];
+            while ($row = $db->coger_Fila()) {
+                $items[] = [
+                    'id'         => $row[0],
+                    'nombre'     => $row[1],
+                    'valor'      => $row[2],
+                    'homologado' => $row[3],
+                    'activo'     => $row[4],
                 ];
             }
             $db->desconexion();
-        }
-
-        $variables = [
-            'sidebarMenu'   => $sidebarMenu,
-            'proveedor'     => $item,
-            'isEdit'        => (bool)$item,
-            'pageTitle'     => $item ? "Editar {$this->title}" : "Nuevo {$this->title}",
-            'UserTitle'      => gettext('sUsuario'),
-            'UserName'       => $_SESSION['nombreUsuario'] ?? 'Guest',
-            'CompanyName'    => $_SESSION['empresa'] ?? null,
-        ];
-
-        try {
-            $template = $twig->load($this->templateDir . '/formulario.twig');
-            return $template->render($variables);
-        } catch (\Exception $e) {
-            return "Error al cargar el formulario de {$this->title}: " . $e->getMessage();
+            return $items;
+        } catch (\Throwable $e) {
+            return [];
         }
     }
 
-    public function Procesar($id = null)
+    protected function getPostData(): array
     {
-        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
-            header("Location: {$this->listRoute}");
-            exit;
-        }
+        return [
+            'nombre'                => trim($_POST['nombre'] ?? ''),
+            'telefono'              => trim($_POST['telefono'] ?? ''),
+            'activo'                => !empty($_POST['activo']) ? 1 : 0,
+            'direccion'             => trim($_POST['direccion'] ?? ''),
+            'web'                   => trim($_POST['web'] ?? ''),
+            'cif'                   => trim($_POST['cif'] ?? ''),
+            'fecha_homologacion'    => trim($_POST['fecha_homologacion'] ?? ''),
+            'ultima_revision'       => trim($_POST['ultima_revision'] ?? ''),
+            'fecha_deshomologacion' => trim($_POST['fecha_deshomologacion'] ?? ''),
+        ];
+    }
 
-        \Tuqan\Classes\Config::initialize();
-
-        if ($id === null) {
-            $id = isset($_POST['id']) ? (int)$_POST['id'] : (isset($_GET['id']) ? (int)$_GET['id'] : null);
-        }
-        $id = (int)$id;
-
-        $nombre   = trim($_POST['nombre'] ?? '');
-        $telefono = trim($_POST['telefono'] ?? '');
-        $activo    = !empty($_POST['activo']) ? 1 : 0;
-
+    protected function validate(array $data): array
+    {
         $errors = [];
-        if ($nombre === '') {
+        if (($data['nombre'] ?? '') === '') {
             $errors[] = 'El nombre del proveedor es obligatorio.';
         }
+        return $errors;
+    }
 
-        if (!empty($errors)) {
-            $_SESSION[$this->flashPrefix . '_form_error'] = implode(' ', $errors);
-            $target = $id > 0 ? "{$this->listRoute}/editar/$id" : "{$this->listRoute}/nuevo";
-            header("Location: $target");
-            exit;
-        }
-
-        $host    = $_SESSION['db_host'] ?? (getenv('DB_HOST') ?: 'localhost');
-        $port    = $_SESSION['db_port'] ?? (int)(getenv('DB_PORT') ?: 5432);
-
-        $db      = new \Tuqan\Classes\Manejador_Base_Datos(
-            $_SESSION['login'] ?? '',
-            $_SESSION['pass'] ?? '',
-            $_SESSION['db'] ?? '',
-            $host,
-            $port
-        );
-
+    protected function persist(array $data, $id)
+    {
+        $db = $this->getDb();
+        $params = [
+            $data['nombre'],
+            $data['telefono'],
+            $data['activo'],
+            $data['direccion'],
+            $data['web'],
+            $data['cif'],
+            $data['fecha_homologacion'] ?: null,
+            $data['ultima_revision'] ?: null,
+            $data['fecha_deshomologacion'] ?: null,
+        ];
         if ($id > 0) {
+            $params[] = $id;
             $db->consultaPreparada(
-                "UPDATE {$this->table} SET nombre = ?, telefono = ? WHERE id = ?",
-                [$nombre, $telefono, $id]
+                "UPDATE {$this->table} SET nombre = ?, telefono = ?, activo = ?, direccion = ?, web = ?, cif = ?,
+                 fecha_homologacion = ?, ultima_revision = ?, fecha_deshomologacion = ? WHERE id = ?",
+                $params
             );
-            $msg = "{$this->title} actualizado correctamente.";
         } else {
             $db->consultaPreparada(
-                "INSERT INTO {$this->table} (nombre, telefono) VALUES (?, ?)",
-                [$nombre, $telefono]
+                "INSERT INTO {$this->table} (nombre, telefono, activo, direccion, web, cif, fecha_homologacion, ultima_revision, fecha_deshomologacion)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                $params
             );
-            $msg = "{$this->title} creado correctamente.";
         }
-
         $db->desconexion();
+    }
 
+    public function Homologar($id = null)
+    {
+        return $this->setHomologacionState($id, true);
+    }
+
+    public function Deshomologar($id = null)
+    {
+        return $this->setHomologacionState($id, false);
+    }
+
+    protected function setHomologacionState($id, bool $homologar)
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            header('Location: ' . $this->listRoute);
+            exit;
+        }
+        Config::initialize();
+        if ($id === null) {
+            $id = (int)($_POST['id'] ?? 0);
+        }
+        $id = (int)$id;
+        if ($id <= 0) {
+            header('Location: ' . $this->listRoute);
+            exit;
+        }
+        $today = date('Y-m-d');
+        $db = $this->getDb();
+        if ($homologar) {
+            $db->consultaPreparada(
+                "UPDATE {$this->table}
+                 SET fecha_homologacion = COALESCE(fecha_homologacion, ?),
+                     ultima_revision = ?,
+                     fecha_deshomologacion = NULL
+                 WHERE id = ?",
+                [$today, $today, $id]
+            );
+            $msg = 'Proveedor homologado.';
+        } else {
+            $db->consultaPreparada(
+                "UPDATE {$this->table} SET fecha_deshomologacion = ?, ultima_revision = ? WHERE id = ?",
+                [$today, $today, $id]
+            );
+            $msg = 'Proveedor deshomologado.';
+        }
+        $db->desconexion();
         $_SESSION[$this->flashPrefix . '_flash_success'] = $msg;
-        header("Location: {$this->listRoute}");
+        header('Location: ' . $this->listRoute);
         exit;
     }
 }

--- a/Pages/Proveedores/HomologacionHelper.php
+++ b/Pages/Proveedores/HomologacionHelper.php
@@ -1,0 +1,36 @@
+<?php
+namespace Tuqan\Pages\Proveedores;
+
+/**
+ * Supplier homologation status helpers (Stage 9.40).
+ */
+class HomologacionHelper
+{
+    /**
+     * Homologado if has fecha_homologacion and no later deshomologacion.
+     */
+    public static function isHomologado(?string $fechaHomologacion, ?string $fechaDeshomologacion): bool
+    {
+        if ($fechaHomologacion === null || $fechaHomologacion === '') {
+            return false;
+        }
+        if ($fechaDeshomologacion === null || $fechaDeshomologacion === '') {
+            return true;
+        }
+        return substr((string)$fechaHomologacion, 0, 10) > substr((string)$fechaDeshomologacion, 0, 10);
+    }
+
+    public static function label(?string $fechaHomologacion, ?string $fechaDeshomologacion): string
+    {
+        return self::isHomologado($fechaHomologacion, $fechaDeshomologacion)
+            ? 'Homologado'
+            : 'No homologado';
+    }
+
+    public static function badgeClass(?string $fechaHomologacion, ?string $fechaDeshomologacion): string
+    {
+        return self::isHomologado($fechaHomologacion, $fechaDeshomologacion)
+            ? 'label-success'
+            : 'label-default';
+    }
+}

--- a/Pages/Proveedores/Listado.php
+++ b/Pages/Proveedores/Listado.php
@@ -1,29 +1,86 @@
 <?php
-
 namespace Tuqan\Pages\Proveedores;
 
 use Tuqan\Pages\Catalog\CatalogListado;
 
 class Listado extends CatalogListado
 {
-    protected string $table         = 'proveedores';
-    protected string $title         = 'Proveedores';
+    protected string $table       = 'proveedores';
+    protected string $title       = 'Proveedores';
     protected string $templateDir = 'proveedores';
     protected string $flashPrefix = 'proveedor';
 
-    // Override for the extra 'telefono' column (base assumes only id/nombre/activo)
     protected function getSelectSql(): string
     {
-        return "SELECT id, nombre, telefono, activo FROM {$this->table} ORDER BY id";
+        return "SELECT id, nombre, telefono, activo, fecha_homologacion, fecha_deshomologacion, ultima_revision FROM {$this->table} ORDER BY id";
     }
 
     protected function mapRow($row): array
     {
         return [
-            'id'       => $row[0],
-            'nombre'   => $row[1],
-            'telefono' => $row[2] ?? null,
-            'activo'   => $row[3],
+            'id'                     => $row[0],
+            'nombre'                 => $row[1],
+            'telefono'               => $row[2] ?? null,
+            'activo'                 => $row[3],
+            'fecha_homologacion'     => $row[4] ?? null,
+            'fecha_deshomologacion'  => $row[5] ?? null,
+            'ultima_revision'        => $row[6] ?? null,
         ];
+    }
+
+    protected function fetchItems(): array
+    {
+        try {
+            $db = $this->getDb();
+            $db->consulta($this->getSelectSql());
+            $items = [];
+            while ($row = $db->coger_Fila()) {
+                $items[] = $this->mapRow($row);
+            }
+            $db->desconexion();
+        } catch (\Throwable $e) {
+            // Fallback if columns not yet applied
+            $items = parent::fetchItems();
+            foreach ($items as &$item) {
+                $item['fecha_homologacion'] = null;
+                $item['fecha_deshomologacion'] = null;
+                $item['ultima_revision'] = null;
+            }
+            unset($item);
+        }
+
+        foreach ($items as &$item) {
+            $item['homologado'] = HomologacionHelper::isHomologado(
+                $item['fecha_homologacion'] ?? null,
+                $item['fecha_deshomologacion'] ?? null
+            );
+            $item['homologacion_label'] = HomologacionHelper::label(
+                $item['fecha_homologacion'] ?? null,
+                $item['fecha_deshomologacion'] ?? null
+            );
+            $item['homologacion_badge'] = HomologacionHelper::badgeClass(
+                $item['fecha_homologacion'] ?? null,
+                $item['fecha_deshomologacion'] ?? null
+            );
+            $item['producto_count'] = $this->countProductos((int)$item['id']);
+        }
+        unset($item);
+        return $items;
+    }
+
+    protected function countProductos(int $proveedorId): int
+    {
+        if ($proveedorId <= 0) {
+            return 0;
+        }
+        try {
+            $db = $this->getDb();
+            $db->consultaPreparada('SELECT COUNT(*) FROM productos WHERE proveedor = ?', [$proveedorId]);
+            $row = $db->coger_Fila();
+            $db->desconexion();
+            return (int)($row[0] ?? 0);
+        } catch (\Throwable $e) {
+            return 0;
+        }
     }
 }

--- a/Pages/Proveedores/Productos/Formulario.php
+++ b/Pages/Proveedores/Productos/Formulario.php
@@ -1,0 +1,157 @@
+<?php
+namespace Tuqan\Pages\Proveedores\Productos;
+
+use Tuqan\Pages\Catalog\CatalogFormulario;
+
+class Formulario extends CatalogFormulario
+{
+    protected string $table        = 'productos';
+    protected string $title        = 'Producto';
+    protected string $templateDir  = 'proveedores/productos';
+    protected string $flashPrefix  = 'producto';
+    protected string $listRoute    = '/admin/proveedores/productos';
+
+    protected function getSelectForForm(): string
+    {
+        return "SELECT id, nombre, proveedor, valor, homologado, activo, fecha_revision FROM {$this->table} WHERE id = ?";
+    }
+
+    protected function loadItem($id): ?array
+    {
+        if ($id <= 0) {
+            return null;
+        }
+        $db = $this->getDb();
+        $db->consultaPreparada($this->getSelectForForm(), [$id]);
+        $row = $db->coger_Fila();
+        $db->desconexion();
+        if (!$row) {
+            return null;
+        }
+        return [
+            'id'             => $row[0],
+            'nombre'         => $row[1],
+            'proveedor'      => $row[2] ?? null,
+            'valor'          => $row[3] ?? 0,
+            'homologado'     => $row[4],
+            'activo'         => $row[5],
+            'fecha_revision' => $row[6] ?? null,
+        ];
+    }
+
+    protected function buildFormVariables(?array $item): array
+    {
+        if ($item === null) {
+            $proveedor = (isset($_GET['proveedor']) && $_GET['proveedor'] !== '') ? (int)$_GET['proveedor'] : null;
+            $item = [
+                'id'             => null,
+                'nombre'         => '',
+                'proveedor'      => $proveedor,
+                'valor'          => 50,
+                'homologado'     => false,
+                'activo'         => true,
+                'fecha_revision' => null,
+            ];
+            // Keep isEdit false: pass null to parent then override key
+            $vars = parent::buildFormVariables(null);
+            $vars[strtolower($this->flashPrefix)] = $item;
+            $vars['isEdit'] = false;
+        } else {
+            $vars = parent::buildFormVariables($item);
+        }
+        $vars['proveedor_options'] = $this->getRelatedOptions('proveedores', 'nombre');
+        $key = strtolower($this->flashPrefix);
+        if (!empty($vars[$key])) {
+            $p = $vars[$key];
+            $p['proveedor_label'] = $this->getRelatedLabel('proveedores', $p['proveedor'] ?? null);
+            $vars[$key] = $p;
+            if (!empty($p['proveedor'])) {
+                $vars['list_return'] = $this->listRoute . '?proveedor=' . (int)$p['proveedor'];
+            } else {
+                $vars['list_return'] = $this->listRoute;
+            }
+        } else {
+            $vars['list_return'] = $this->listRoute;
+        }
+        return $vars;
+    }
+
+    protected function getPostData(): array
+    {
+        return [
+            'nombre'         => trim($_POST['nombre'] ?? ''),
+            'proveedor'      => isset($_POST['proveedor']) && $_POST['proveedor'] !== '' ? (int)$_POST['proveedor'] : null,
+            'valor'          => isset($_POST['valor']) ? (int)$_POST['valor'] : 0,
+            'homologado'     => !empty($_POST['homologado']) ? 1 : 0,
+            'activo'         => !empty($_POST['activo']) ? 1 : 0,
+            'fecha_revision' => trim($_POST['fecha_revision'] ?? ''),
+        ];
+    }
+
+    protected function validate(array $data): array
+    {
+        $errors = [];
+        if (($data['nombre'] ?? '') === '') {
+            $errors[] = 'El nombre del producto es obligatorio.';
+        }
+        return $errors;
+    }
+
+    protected function persist(array $data, $id)
+    {
+        $db = $this->getDb();
+        $params = [
+            $data['nombre'],
+            $data['proveedor'],
+            $data['valor'],
+            $data['homologado'],
+            $data['activo'],
+            $data['fecha_revision'] ?: null,
+        ];
+        if ($id > 0) {
+            $params[] = $id;
+            $db->consultaPreparada(
+                "UPDATE {$this->table} SET nombre = ?, proveedor = ?, valor = ?, homologado = ?, activo = ?, fecha_revision = ? WHERE id = ?",
+                $params
+            );
+        } else {
+            $db->consultaPreparada(
+                "INSERT INTO {$this->table} (nombre, proveedor, valor, homologado, activo, fecha_revision) VALUES (?, ?, ?, ?, ?, ?)",
+                $params
+            );
+        }
+        $db->desconexion();
+    }
+
+    public function Procesar($id = null)
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+            header('Location: ' . $this->listRoute);
+            exit;
+        }
+        \Tuqan\Classes\Config::initialize();
+        if ($id === null) {
+            $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+        }
+        $id = (int)$id;
+        $data = $this->getPostData();
+        $errors = $this->validate($data);
+        if (!empty($errors)) {
+            $_SESSION[$this->flashPrefix . '_form_error'] = implode(' ', $errors);
+            $target = $id > 0 ? "{$this->listRoute}/editar/$id" : "{$this->listRoute}/nuevo";
+            if (!empty($data['proveedor'])) {
+                $target .= (strpos($target, '?') === false ? '?' : '&') . 'proveedor=' . (int)$data['proveedor'];
+            }
+            header("Location: $target");
+            exit;
+        }
+        $this->persist($data, $id);
+        $_SESSION[$this->flashPrefix . '_flash_success'] = $this->getSuccessMessage($id > 0);
+        $loc = $this->listRoute;
+        if (!empty($data['proveedor'])) {
+            $loc .= '?proveedor=' . (int)$data['proveedor'];
+        }
+        header("Location: $loc");
+        exit;
+    }
+}

--- a/Pages/Proveedores/Productos/Listado.php
+++ b/Pages/Proveedores/Productos/Listado.php
@@ -1,0 +1,76 @@
+<?php
+namespace Tuqan\Pages\Proveedores\Productos;
+
+use Tuqan\Pages\Catalog\CatalogListado;
+
+class Listado extends CatalogListado
+{
+    protected string $table       = 'productos';
+    protected string $title       = 'Productos de Proveedores';
+    protected string $templateDir = 'proveedores/productos';
+    protected string $flashPrefix = 'producto';
+
+    protected function getSelectSql(): string
+    {
+        return "SELECT id, nombre, proveedor, valor, homologado, activo, fecha_revision FROM {$this->table} ORDER BY id";
+    }
+
+    protected function mapRow($row): array
+    {
+        return [
+            'id'             => $row[0],
+            'nombre'         => $row[1],
+            'proveedor'      => $row[2] ?? null,
+            'valor'          => $row[3] ?? 0,
+            'homologado'     => $row[4],
+            'activo'         => $row[5],
+            'fecha_revision' => $row[6] ?? null,
+        ];
+    }
+
+    protected function fetchItems(): array
+    {
+        $filters = $this->getFilterParams();
+        // reuse equipo slot? No - add proveedor via GET directly (getFilterParams has no proveedor)
+        $proveedor = (isset($_GET['proveedor']) && $_GET['proveedor'] !== '') ? (int)$_GET['proveedor'] : null;
+
+        $sql = "SELECT id, nombre, proveedor, valor, homologado, activo, fecha_revision FROM {$this->table}";
+        $params = [];
+        if ($proveedor !== null && $proveedor > 0) {
+            $sql .= ' WHERE proveedor = ?';
+            $params[] = $proveedor;
+        }
+        $sql .= ' ORDER BY id DESC';
+
+        $db = $this->getDb();
+        if ($params) {
+            $db->consultaPreparada($sql, $params);
+        } else {
+            $db->consulta($sql);
+        }
+        $items = [];
+        while ($row = $db->coger_Fila()) {
+            $items[] = $this->mapRow($row);
+        }
+        $db->desconexion();
+
+        foreach ($items as &$item) {
+            $item['proveedor_label'] = $this->getRelatedLabel('proveedores', $item['proveedor'] ?? null);
+        }
+        unset($item);
+        return $items;
+    }
+
+    protected function buildListVariables(array $items): array
+    {
+        $vars = parent::buildListVariables($items);
+        $vars['producto'] = $items;
+        $proveedor = (isset($_GET['proveedor']) && $_GET['proveedor'] !== '') ? (int)$_GET['proveedor'] : null;
+        $vars['filter_proveedor'] = $proveedor;
+        $vars['proveedor_options'] = $this->getRelatedOptions('proveedores', 'nombre');
+        if ($proveedor) {
+            $vars['filter_proveedor_label'] = $this->getRelatedLabel('proveedores', $proveedor);
+        }
+        return $vars;
+    }
+}

--- a/docker/db-init/data-patches/0050-proveedores-homologacion.sql
+++ b/docker/db-init/data-patches/0050-proveedores-homologacion.sql
@@ -1,0 +1,71 @@
+-- 0050-proveedores-homologacion.sql
+-- Stage 9.40: Homologation fields on proveedores + criterios + productos shells.
+
+ALTER TABLE proveedores ADD COLUMN IF NOT EXISTS direccion TEXT;
+ALTER TABLE proveedores ADD COLUMN IF NOT EXISTS web VARCHAR(255);
+ALTER TABLE proveedores ADD COLUMN IF NOT EXISTS cif VARCHAR(20);
+ALTER TABLE proveedores ADD COLUMN IF NOT EXISTS fecha_homologacion DATE;
+ALTER TABLE proveedores ADD COLUMN IF NOT EXISTS ultima_revision DATE;
+ALTER TABLE proveedores ADD COLUMN IF NOT EXISTS fecha_deshomologacion DATE;
+
+CREATE TABLE IF NOT EXISTS criterios_homologacion (
+  id     SERIAL PRIMARY KEY,
+  nombre CHARACTER VARYING(255) NOT NULL,
+  valor  INTEGER DEFAULT 0,
+  activo BOOLEAN DEFAULT true
+);
+
+CREATE TABLE IF NOT EXISTS productos (
+  id             SERIAL PRIMARY KEY,
+  valor          INTEGER DEFAULT 0,
+  proveedor      INTEGER REFERENCES proveedores (id),
+  criterios      INTEGER [],
+  fecha_revision DATE,
+  nombre         CHARACTER VARYING(128) NOT NULL,
+  activo         BOOLEAN DEFAULT true,
+  homologado     BOOLEAN DEFAULT false
+);
+
+-- Seed criteria
+INSERT INTO criterios_homologacion (nombre, valor, activo)
+SELECT 'Certificación ISO 9001', 30, true
+WHERE NOT EXISTS (SELECT 1 FROM criterios_homologacion WHERE nombre = 'Certificación ISO 9001');
+
+INSERT INTO criterios_homologacion (nombre, valor, activo)
+SELECT 'Entregas a tiempo', 25, true
+WHERE NOT EXISTS (SELECT 1 FROM criterios_homologacion WHERE nombre = 'Entregas a tiempo');
+
+INSERT INTO criterios_homologacion (nombre, valor, activo)
+SELECT 'Calidad del producto', 35, true
+WHERE NOT EXISTS (SELECT 1 FROM criterios_homologacion WHERE nombre = 'Calidad del producto');
+
+INSERT INTO criterios_homologacion (nombre, valor, activo)
+SELECT 'Servicio postventa', 10, true
+WHERE NOT EXISTS (SELECT 1 FROM criterios_homologacion WHERE nombre = 'Servicio postventa');
+
+-- Demo homologation on proveedor 1
+UPDATE proveedores SET
+  fecha_homologacion = COALESCE(fecha_homologacion, CURRENT_DATE - INTERVAL '180 days'),
+  ultima_revision = COALESCE(ultima_revision, CURRENT_DATE - INTERVAL '30 days'),
+  fecha_deshomologacion = NULL
+WHERE id = 1;
+
+-- Demo products
+INSERT INTO productos (nombre, proveedor, valor, homologado, activo, fecha_revision)
+SELECT 'Producto homologado A', 1, 50, true, true, CURRENT_DATE - INTERVAL '30 days'
+WHERE EXISTS (SELECT 1 FROM proveedores WHERE id = 1)
+  AND NOT EXISTS (SELECT 1 FROM productos WHERE nombre = 'Producto homologado A' AND proveedor = 1);
+
+INSERT INTO productos (nombre, proveedor, valor, homologado, activo, fecha_revision)
+SELECT 'Producto pendiente B', 1, 70, false, true, NULL
+WHERE EXISTS (SELECT 1 FROM proveedores WHERE id = 1)
+  AND NOT EXISTS (SELECT 1 FROM productos WHERE nombre = 'Producto pendiente B' AND proveedor = 1);
+
+INSERT INTO productos (nombre, proveedor, valor, homologado, activo, fecha_revision)
+SELECT 'Suministro estándar', 2, 40, false, true, NULL
+WHERE EXISTS (SELECT 1 FROM proveedores WHERE id = 2)
+  AND NOT EXISTS (SELECT 1 FROM productos WHERE nombre = 'Suministro estándar' AND proveedor = 2);
+
+INSERT INTO data_patches (filename, applied_at)
+VALUES ('0050-proveedores-homologacion.sql', NOW())
+ON CONFLICT (filename) DO NOTHING;

--- a/index.php
+++ b/index.php
@@ -325,8 +325,26 @@ $router->addRoute('GET', '/admin/proveedores/editar/{id}', ['Tuqan\Pages\Proveed
 $router->addRoute('POST', '/admin/proveedores/nuevo', ['Tuqan\Pages\Proveedores\Formulario', 'Procesar'], ['before' => 'auth_company']);
 $router->addRoute('POST', '/admin/proveedores/editar/{id}', ['Tuqan\Pages\Proveedores\Formulario', 'Procesar'], ['before' => 'auth_company']);
 
+// Homologar / Deshomologar (Stage 9.40)
+$router->addRoute('POST', '/admin/proveedores/homologar/{id}', ['Tuqan\Pages\Proveedores\Formulario', 'Homologar'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/proveedores/deshomologar/{id}', ['Tuqan\Pages\Proveedores\Formulario', 'Deshomologar'], ['before' => 'auth_company']);
+
+// Productos + Criterios homologación (Stage 9.40)
+$router->addRoute('GET', '/admin/proveedores/productos', ['Tuqan\Pages\Proveedores\Productos\Listado', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/proveedores/productos/nuevo', ['Tuqan\Pages\Proveedores\Productos\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/proveedores/productos/editar/{id}', ['Tuqan\Pages\Proveedores\Productos\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/proveedores/productos/nuevo', ['Tuqan\Pages\Proveedores\Productos\Formulario', 'Procesar'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/proveedores/productos/editar/{id}', ['Tuqan\Pages\Proveedores\Productos\Formulario', 'Procesar'], ['before' => 'auth_company']);
+
+$router->addRoute('GET', '/admin/proveedores/criterios', ['Tuqan\Pages\Proveedores\Criterios\Listado', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/proveedores/criterios/nuevo', ['Tuqan\Pages\Proveedores\Criterios\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/admin/proveedores/criterios/editar/{id}', ['Tuqan\Pages\Proveedores\Criterios\Formulario', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/proveedores/criterios/nuevo', ['Tuqan\Pages\Proveedores\Criterios\Formulario', 'Procesar'], ['before' => 'auth_company']);
+$router->addRoute('POST', '/admin/proveedores/criterios/editar/{id}', ['Tuqan\Pages\Proveedores\Criterios\Formulario', 'Procesar'], ['before' => 'auth_company']);
+
 // Legacy routes for Proveedores (from full legacy menu accions)
 $router->addRoute('GET', '/administracion/proveedores/listado/ver', ['Tuqan\Pages\Proveedores\Listado', 'ShowPage'], ['before' => 'auth_company']);
+$router->addRoute('GET', '/administracion/proveedores/phomologados/listado/ver', ['Tuqan\Pages\Proveedores\Productos\Listado', 'ShowPage'], ['before' => 'auth_company']);
 
 // === Equipos (Stage 9.3) ===
 $router->addRoute('GET', '/admin/equipos', ['Tuqan\Pages\Equipos\Listado', 'ShowPage'], ['before' => 'auth_company']);

--- a/reference/stage-9.40-proveedores-homologacion-plan.md
+++ b/reference/stage-9.40-proveedores-homologacion-plan.md
@@ -1,6 +1,6 @@
 # Stage 9.40 — Proveedores homologación first slice
 
-**Status**: Planning (plan first)
+**Status**: Implemented (verify + PR)
 **Branch**: `feat/stage-9.40-proveedores-homologacion`
 **Driver**: Sized next after 9.39. Proveedores shell is nombre/telefono only (9.2). Legacy has fecha_homologacion/deshomologacion, productos.homologado, criterios_homologacion.
 

--- a/reference/stage-9.40-proveedores-homologacion-plan.md
+++ b/reference/stage-9.40-proveedores-homologacion-plan.md
@@ -1,0 +1,22 @@
+# Stage 9.40 — Proveedores homologación first slice
+
+**Status**: Planning (plan first)
+**Branch**: `feat/stage-9.40-proveedores-homologacion`
+**Driver**: Sized next after 9.39. Proveedores shell is nombre/telefono only (9.2). Legacy has fecha_homologacion/deshomologacion, productos.homologado, criterios_homologacion.
+
+## Goals
+1. Patch **0050**: extend `proveedores` (homologation dates + optional contact fields); CREATE `criterios_homologacion` + `productos`; demo seeds.
+2. Proveedor list/form: homologation status + dates; quick Homologar / Deshomologar; producto count + link.
+3. `Pages/Proveedores/Productos/{Listado,Formulario}` — filter/prefill by proveedor; homologado flag.
+4. `Pages/Proveedores/Criterios/{Listado,Formulario}` — simple catalog (nombre, valor, activo).
+5. Routes modern + verify + playbook + TODOS.
+
+## Out
+- Full criteria multi-select scoring + historico_productos workflow; contactos/incidencias.
+
+## Sizing
+- One outcome: manage supplier homologation + product homologado + criteria catalog.
+- ~15–18 files, 1 patch (near ceiling; single vertical).
+
+---
+*Plan committed first. Docker-only.*

--- a/scripts/verify-8.6.sh
+++ b/scripts/verify-8.6.sh
@@ -173,6 +173,13 @@ SELECT cb.id, cb.nombre_archivo, cb.size, tf.extension
   LEFT JOIN tipos_fichero tf ON tf.id = cb.tipo_fichero
  ORDER BY cb.id LIMIT 5;
 
+-- 9.40 Proveedores homologación evidence
+SELECT '0050-proveedores-homologacion.sql' AS patch, COUNT(*) FROM data_patches WHERE filename = '0050-proveedores-homologacion.sql';
+SELECT COUNT(*) AS proveedores_homologados FROM proveedores WHERE fecha_homologacion IS NOT NULL AND (fecha_deshomologacion IS NULL OR fecha_homologacion > fecha_deshomologacion);
+SELECT COUNT(*) AS criterios_homologacion_rows FROM criterios_homologacion;
+SELECT COUNT(*) AS productos_rows FROM productos;
+SELECT COUNT(*) AS productos_homologados FROM productos WHERE homologado = true;
+
 -- 9.5 Formación (Planes) + Documentación evidence
 SELECT COUNT(*) AS plan_formacion_rows FROM plan_formacion;
 SELECT COUNT(*) AS documentos_rows FROM documentos;

--- a/templates/proveedores/criterios/formulario.twig
+++ b/templates/proveedores/criterios/formulario.twig
@@ -1,0 +1,49 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}{{ pageTitle }} - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <h2 style="margin: 0; font-size: 20px;">{{ pageTitle }}</h2>
+        <div>
+            <a href="/admin/proveedores/criterios" class="btn btn-default btn-sm">Volver</a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px; max-width: 560px;">
+    <form method="POST" action="{{ isEdit ? '/admin/proveedores/criterios/editar/' ~ criterio.id : '/admin/proveedores/criterios/nuevo' }}">
+        {% if isEdit %}
+            <input type="hidden" name="id" value="{{ criterio.id }}">
+        {% endif %}
+
+        <div class="form-group">
+            <label for="nombre">Nombre</label>
+            <input type="text" class="form-control" id="nombre" name="nombre"
+                   value="{{ criterio.nombre ?? '' }}" required>
+        </div>
+
+        <div class="form-group">
+            <label for="valor">Valor (puntos)</label>
+            <input type="number" class="form-control" id="valor" name="valor"
+                   value="{{ criterio.valor ?? 0 }}" min="0">
+        </div>
+
+        <div class="form-group">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="activo" value="1"
+                           {% if not isEdit or criterio.activo %}checked{% endif %}>
+                    Activo
+                </label>
+            </div>
+        </div>
+
+        <div class="form-group" style="margin-top: 20px;">
+            <button type="submit" class="btn btn-primary">{{ isEdit ? 'Guardar' : 'Crear' }}</button>
+            <a href="/admin/proveedores/criterios" class="btn btn-default" style="margin-left:8px;">Cancelar</a>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/templates/proveedores/criterios/listado.twig
+++ b/templates/proveedores/criterios/listado.twig
@@ -1,0 +1,54 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}Criterios de Homologación - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <h2 style="margin: 0; font-size: 20px;">Criterios de Homologación</h2>
+        <div>
+            <a href="/admin/proveedores" class="btn btn-default btn-sm">Proveedores</a>
+            <a href="/admin/proveedores/productos" class="btn btn-default btn-sm">Productos</a>
+            <a href="/admin/proveedores/criterios/nuevo" class="btn btn-primary btn-sm">
+                <span class="glyphicon glyphicon-plus"></span> Nuevo Criterio
+            </a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px;">
+    {% if criterio is empty %}
+        <div class="alert alert-info">No hay criterios de homologación.</div>
+    {% else %}
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Nombre</th>
+                        <th>Valor</th>
+                        <th>Activo</th>
+                        <th style="width:100px;text-align:right;">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for c in criterio %}
+                    <tr>
+                        <td>{{ c.id }}</td>
+                        <td><strong>{{ c.nombre }}</strong></td>
+                        <td>{{ c.valor ?? 0 }}</td>
+                        <td>{% if c.activo %}<span class="label label-success">Sí</span>{% else %}<span class="label label-default">No</span>{% endif %}</td>
+                        <td style="text-align:right;">
+                            <a href="/admin/proveedores/criterios/editar/{{ c.id }}" class="btn btn-xs btn-default">Editar</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+    <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
+        Criterios (Stage 9.40). Asignación multi-select a productos y scoring automático deferred.
+    </div>
+</div>
+{% endblock %}

--- a/templates/proveedores/formulario.twig
+++ b/templates/proveedores/formulario.twig
@@ -4,15 +4,21 @@
 
 {% block content %}
 <div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
-    <div style="display: flex; justify-content: space-between; align-items: center;">
+    <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 8px;">
         <h2 style="margin: 0; font-size: 20px;">{{ pageTitle }}</h2>
         <div>
             <a href="/admin/proveedores" class="btn btn-default btn-sm">Volver al listado</a>
+            {% if isEdit and proveedor.id %}
+            <a href="/admin/proveedores/productos?proveedor={{ proveedor.id }}" class="btn btn-default btn-sm">Productos</a>
+            {% endif %}
         </div>
     </div>
 </div>
 
-<div style="padding: 20px; max-width: 600px;">
+<div style="padding: 20px; max-width: 720px;">
+    {% if flash_success %}<div class="alert alert-success">{{ flash_success }}</div>{% endif %}
+    {% if flash_error %}<div class="alert alert-danger">{{ flash_error }}</div>{% endif %}
+
     <form method="POST" action="{{ isEdit ? '/admin/proveedores/editar/' ~ proveedor.id : '/admin/proveedores/nuevo' }}">
         {% if isEdit %}
             <input type="hidden" name="id" value="{{ proveedor.id }}">
@@ -24,11 +30,69 @@
                    value="{{ proveedor.nombre ?? '' }}" required>
         </div>
 
-        <div class="form-group">
-            <label for="telefono">Teléfono</label>
-            <input type="text" class="form-control" id="telefono" name="telefono"
-                   value="{{ proveedor.telefono ?? '' }}">
+        <div class="row">
+            <div class="col-sm-6">
+                <div class="form-group">
+                    <label for="telefono">Teléfono</label>
+                    <input type="text" class="form-control" id="telefono" name="telefono"
+                           value="{{ proveedor.telefono ?? '' }}">
+                </div>
+            </div>
+            <div class="col-sm-6">
+                <div class="form-group">
+                    <label for="cif">CIF</label>
+                    <input type="text" class="form-control" id="cif" name="cif"
+                           value="{{ proveedor.cif ?? '' }}">
+                </div>
+            </div>
         </div>
+
+        <div class="form-group">
+            <label for="direccion">Dirección</label>
+            <input type="text" class="form-control" id="direccion" name="direccion"
+                   value="{{ proveedor.direccion ?? '' }}">
+        </div>
+
+        <div class="form-group">
+            <label for="web">Web</label>
+            <input type="text" class="form-control" id="web" name="web"
+                   value="{{ proveedor.web ?? '' }}">
+        </div>
+
+        <fieldset style="margin-top: 16px; padding-top: 12px; border-top: 1px solid #eee;">
+            <legend style="font-size: 14px; border:0; margin-bottom: 10px;">Homologación</legend>
+            {% if isEdit %}
+            <p>
+                Estado:
+                <span class="label {{ proveedor.homologacion_badge|default('label-default') }}">
+                    {{ proveedor.homologacion_label ?? '—' }}
+                </span>
+            </p>
+            {% endif %}
+            <div class="row">
+                <div class="col-sm-4">
+                    <div class="form-group">
+                        <label for="fecha_homologacion">Fecha homologación</label>
+                        <input type="date" class="form-control" id="fecha_homologacion" name="fecha_homologacion"
+                               value="{{ proveedor.fecha_homologacion ?? '' }}">
+                    </div>
+                </div>
+                <div class="col-sm-4">
+                    <div class="form-group">
+                        <label for="ultima_revision">Última revisión</label>
+                        <input type="date" class="form-control" id="ultima_revision" name="ultima_revision"
+                               value="{{ proveedor.ultima_revision ?? '' }}">
+                    </div>
+                </div>
+                <div class="col-sm-4">
+                    <div class="form-group">
+                        <label for="fecha_deshomologacion">Fecha deshomologación</label>
+                        <input type="date" class="form-control" id="fecha_deshomologacion" name="fecha_deshomologacion"
+                               value="{{ proveedor.fecha_deshomologacion ?? '' }}">
+                    </div>
+                </div>
+            </div>
+        </fieldset>
 
         <div class="form-group">
             <div class="checkbox">
@@ -45,11 +109,49 @@
                 {{ isEdit ? 'Guardar cambios' : 'Crear Proveedor' }}
             </button>
             <a href="/admin/proveedores" class="btn btn-default" style="margin-left: 8px;">Cancelar</a>
-        </div>
-
-        <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
-            Proveedores (Stage 9.2). Sub-entidades (contactos, incidencias, productos) en legs posteriores.
+            {% if isEdit and proveedor.id %}
+                {% if not proveedor.homologado %}
+                <button type="submit" formaction="/admin/proveedores/homologar/{{ proveedor.id }}" class="btn btn-success" style="margin-left:8px;">Homologar ahora</button>
+                {% else %}
+                <button type="submit" formaction="/admin/proveedores/deshomologar/{{ proveedor.id }}" class="btn btn-warning" style="margin-left:8px;"
+                        onclick="return confirm('¿Deshomologar?');">Deshomologar</button>
+                {% endif %}
+            {% endif %}
         </div>
     </form>
+
+    {% if isEdit and proveedor.id %}
+    <div style="margin-top: 28px; padding-top: 16px; border-top: 1px solid #eee;">
+        <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px;">
+            <h4 style="margin:0; font-size:16px;">Productos ({{ productos_relacionados|length }})</h4>
+            <div>
+                <a href="/admin/proveedores/productos?proveedor={{ proveedor.id }}" class="btn btn-default btn-sm">Ver listado</a>
+                <a href="/admin/proveedores/productos/nuevo?proveedor={{ proveedor.id }}" class="btn btn-primary btn-sm">Nuevo producto</a>
+            </div>
+        </div>
+        {% if productos_relacionados is empty %}
+            <div class="alert alert-info" style="margin-bottom:0;">Sin productos. Puede dar de alta productos homologados o pendientes.</div>
+        {% else %}
+            <table class="table table-condensed table-striped">
+                <thead><tr><th>ID</th><th>Nombre</th><th>Umbral</th><th>Homologado</th><th></th></tr></thead>
+                <tbody>
+                {% for pr in productos_relacionados %}
+                    <tr>
+                        <td>{{ pr.id }}</td>
+                        <td>{{ pr.nombre }}</td>
+                        <td>{{ pr.valor }}</td>
+                        <td>{% if pr.homologado %}<span class="label label-success">Sí</span>{% else %}<span class="label label-default">No</span>{% endif %}</td>
+                        <td style="text-align:right;"><a href="/admin/proveedores/productos/editar/{{ pr.id }}" class="btn btn-xs btn-default">Editar</a></td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+    </div>
+    {% endif %}
+
+    <div class="alert alert-info" style="margin-top: 20px; font-size: 13px;">
+        Proveedores homologación (Stage 9.40). Scoring multi-criterio sobre productos deferred.
+    </div>
 </div>
 {% endblock %}

--- a/templates/proveedores/listado.twig
+++ b/templates/proveedores/listado.twig
@@ -4,9 +4,11 @@
 
 {% block content %}
 <div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
-    <div style="display: flex; justify-content: space-between; align-items: center;">
+    <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 8px;">
         <h2 style="margin: 0; font-size: 20px;">Proveedores</h2>
         <div>
+            <a href="/admin/proveedores/productos" class="btn btn-default btn-sm">Productos</a>
+            <a href="/admin/proveedores/criterios" class="btn btn-default btn-sm">Criterios</a>
             <a href="/admin/proveedores/nuevo" class="btn btn-primary btn-sm">
                 <span class="glyphicon glyphicon-plus"></span> Nuevo Proveedor
             </a>
@@ -15,13 +17,24 @@
 </div>
 
 <div style="padding: 20px;">
+    {% if flashSuccess %}
+        <div class="alert alert-success">{{ flashSuccess }}</div>
+    {% endif %}
     {% if proveedores is empty %}
         <div class="alert alert-info">No hay proveedores registrados.</div>
     {% else %}
         <div class="table-responsive">
             <table class="table table-striped table-hover">
                 <thead>
-                    <tr><th>ID</th><th>Nombre</th><th>Teléfono</th><th>Estado</th><th style="width:140px;text-align:right;">Acciones</th></tr>
+                    <tr>
+                        <th>ID</th>
+                        <th>Nombre</th>
+                        <th>Teléfono</th>
+                        <th>Homologación</th>
+                        <th>Productos</th>
+                        <th>Activo</th>
+                        <th style="width:280px;text-align:right;">Acciones</th>
+                    </tr>
                 </thead>
                 <tbody>
                     {% for p in proveedores %}
@@ -29,9 +42,31 @@
                         <td>{{ p.id }}</td>
                         <td><strong>{{ p.nombre }}</strong></td>
                         <td>{{ p.telefono ?? '-' }}</td>
+                        <td>
+                            <span class="label {{ p.homologacion_badge|default('label-default') }}">{{ p.homologacion_label ?? '—' }}</span>
+                            {% if p.fecha_homologacion %}<div class="text-muted" style="font-size:11px;">desde {{ p.fecha_homologacion }}</div>{% endif %}
+                        </td>
+                        <td>
+                            {% if p.producto_count > 0 %}
+                                <a href="/admin/proveedores/productos?proveedor={{ p.id }}">{{ p.producto_count }}</a>
+                            {% else %}
+                                <span class="text-muted">0</span>
+                            {% endif %}
+                        </td>
                         <td>{% if p.activo %}<span class="label label-success">Activo</span>{% else %}<span class="label label-default">Inactivo</span>{% endif %}</td>
-                        <td style="text-align:right;">
+                        <td style="text-align:right; white-space: nowrap;">
                             <a href="/admin/proveedores/editar/{{ p.id }}" class="btn btn-xs btn-default">Editar</a>
+                            <a href="/admin/proveedores/productos/nuevo?proveedor={{ p.id }}" class="btn btn-xs btn-info">+ Producto</a>
+                            {% if not p.homologado %}
+                            <form method="POST" action="/admin/proveedores/homologar/{{ p.id }}" style="display:inline;margin:0;">
+                                <button type="submit" class="btn btn-xs btn-success">Homologar</button>
+                            </form>
+                            {% else %}
+                            <form method="POST" action="/admin/proveedores/deshomologar/{{ p.id }}" style="display:inline;margin:0;">
+                                <button type="submit" class="btn btn-xs btn-warning"
+                                        onclick="return confirm('¿Deshomologar este proveedor?');">Deshomologar</button>
+                            </form>
+                            {% endif %}
                         </td>
                     </tr>
                     {% endfor %}
@@ -40,7 +75,7 @@
         </div>
     {% endif %}
     <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
-        Proveedores (Stage 9.2). Contactos, incidencias y productos homologados se gestionarán en seguimientos posteriores.
+        Proveedores (9.2 + 9.40 homologación). Contactos e incidencias deferred. Scoring multi-criterio de productos deferred.
     </div>
 </div>
 {% endblock %}

--- a/templates/proveedores/productos/formulario.twig
+++ b/templates/proveedores/productos/formulario.twig
@@ -1,0 +1,80 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}{{ pageTitle }} - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+        <h2 style="margin: 0; font-size: 20px;">{{ pageTitle }}</h2>
+        <div>
+            <a href="{{ list_return|default('/admin/proveedores/productos') }}" class="btn btn-default btn-sm">Volver</a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px; max-width: 640px;">
+    <form method="POST" action="{{ isEdit ? '/admin/proveedores/productos/editar/' ~ producto.id : '/admin/proveedores/productos/nuevo' }}">
+        {% if isEdit %}
+            <input type="hidden" name="id" value="{{ producto.id }}">
+        {% endif %}
+
+        <div class="form-group">
+            <label for="nombre">Nombre</label>
+            <input type="text" class="form-control" id="nombre" name="nombre"
+                   value="{{ producto.nombre ?? '' }}" required>
+        </div>
+
+        <div class="form-group">
+            <label for="proveedor">Proveedor</label>
+            <select class="form-control" id="proveedor" name="proveedor">
+                <option value="">-- Seleccionar --</option>
+                {% for p in proveedor_options %}
+                    <option value="{{ p.id }}" {% if p.id == producto.proveedor %}selected{% endif %}>{{ p.nombre }}</option>
+                {% endfor %}
+            </select>
+        </div>
+
+        <div class="row">
+            <div class="col-sm-6">
+                <div class="form-group">
+                    <label for="valor">Umbral de valoración</label>
+                    <input type="number" class="form-control" id="valor" name="valor"
+                           value="{{ producto.valor ?? 50 }}" min="0">
+                </div>
+            </div>
+            <div class="col-sm-6">
+                <div class="form-group">
+                    <label for="fecha_revision">Fecha revisión</label>
+                    <input type="date" class="form-control" id="fecha_revision" name="fecha_revision"
+                           value="{{ producto.fecha_revision ?? '' }}">
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="homologado" value="1"
+                           {% if producto.homologado %}checked{% endif %}>
+                    Producto homologado
+                </label>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="activo" value="1"
+                           {% if not isEdit or producto.activo %}checked{% endif %}>
+                    Activo
+                </label>
+            </div>
+        </div>
+
+        <div class="form-group" style="margin-top: 20px;">
+            <button type="submit" class="btn btn-primary">{{ isEdit ? 'Guardar' : 'Crear' }}</button>
+            <a href="{{ list_return|default('/admin/proveedores/productos') }}" class="btn btn-default" style="margin-left:8px;">Cancelar</a>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/templates/proveedores/productos/listado.twig
+++ b/templates/proveedores/productos/listado.twig
@@ -1,0 +1,80 @@
+{% extends "layouts/app.twig" %}
+
+{% block title %}Productos de Proveedores - Tuqan{% endblock %}
+
+{% block content %}
+<div class="page-header" style="padding: 15px 20px; border-bottom: 1px solid #ddd; background: #fff;">
+    <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 8px;">
+        <h2 style="margin: 0; font-size: 20px;">Productos de Proveedores</h2>
+        <div>
+            <a href="/admin/proveedores" class="btn btn-default btn-sm">Proveedores</a>
+            <a href="/admin/proveedores/criterios" class="btn btn-default btn-sm">Criterios</a>
+            <a href="/admin/proveedores/productos/nuevo{% if filter_proveedor %}?proveedor={{ filter_proveedor }}{% endif %}" class="btn btn-primary btn-sm">
+                <span class="glyphicon glyphicon-plus"></span> Nuevo Producto
+            </a>
+        </div>
+    </div>
+</div>
+
+<div style="padding: 20px;">
+    <form method="GET" action="/admin/proveedores/productos" class="form-inline" style="margin-bottom: 15px;">
+        <div class="form-group" style="margin-right: 8px;">
+            <label for="proveedor" style="margin-right: 6px;">Proveedor</label>
+            <select class="form-control input-sm" id="proveedor" name="proveedor">
+                <option value="">-- Todos --</option>
+                {% for p in proveedor_options %}
+                    <option value="{{ p.id }}" {% if filter_proveedor == p.id %}selected{% endif %}>{{ p.nombre }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button type="submit" class="btn btn-default btn-sm">Filtrar</button>
+        {% if filter_proveedor %}
+            <a href="/admin/proveedores/productos" class="btn btn-link btn-sm">Quitar filtro</a>
+        {% endif %}
+    </form>
+
+    {% if producto is empty %}
+        <div class="alert alert-info">No hay productos{% if filter_proveedor %} para este proveedor{% endif %}.</div>
+    {% else %}
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Nombre</th>
+                        <th>Proveedor</th>
+                        <th>Umbral</th>
+                        <th>Homologado</th>
+                        <th>Revisión</th>
+                        <th>Activo</th>
+                        <th style="width:100px;text-align:right;">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for r in producto %}
+                    <tr>
+                        <td>{{ r.id }}</td>
+                        <td><strong>{{ r.nombre }}</strong></td>
+                        <td>
+                            {% if r.proveedor %}
+                                <a href="/admin/proveedores/editar/{{ r.proveedor }}">{{ r.proveedor_label ?? r.proveedor }}</a>
+                            {% else %}-{% endif %}
+                        </td>
+                        <td>{{ r.valor ?? 0 }}</td>
+                        <td>{% if r.homologado %}<span class="label label-success">Sí</span>{% else %}<span class="label label-default">No</span>{% endif %}</td>
+                        <td>{{ r.fecha_revision ?? '—' }}</td>
+                        <td>{% if r.activo %}<span class="label label-success">Sí</span>{% else %}<span class="label label-default">No</span>{% endif %}</td>
+                        <td style="text-align:right;">
+                            <a href="/admin/proveedores/productos/editar/{{ r.id }}" class="btn btn-xs btn-default">Editar</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+    <div class="alert alert-info" style="margin-top:15px;font-size:13px;">
+        Productos (Stage 9.40). Umbral/valor listo para scoring multi-criterio (deferred).
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Patch **0050**: homologation columns on `proveedores`; `criterios_homologacion` + `productos`; demo seeds
- Proveedor list/form: status badge, dates, **Homologar** / **Deshomologar**, product counts
- Productos CRUD with proveedor filter/prefill + homologado flag
- Criterios catalog (nombre, valor, activo)
- verify + living docs

## Out of scope
- Multi-criterio scoring + historico_productos; contactos/incidencias

## Test plan
- [ ] Apply 0050 / verify
- [ ] `/admin/proveedores` — Homologar/Deshomologar
- [ ] Productos filter by proveedor; create product
- [ ] Criterios CRUD